### PR TITLE
[Dream] 꿈 작성 UI 레이아웃 구현

### DIFF
--- a/lib/presentation/dream/dream_write_page.dart
+++ b/lib/presentation/dream/dream_write_page.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mongbi_app/core/font.dart';
+import 'package:mongbi_app/presentation/dream/widgets/dream_content_input.dart';
+import 'package:mongbi_app/presentation/dream/widgets/mood_selection_row.dart';
+import 'package:mongbi_app/presentation/dream/widgets/submit_dream_button.dart';
+import 'package:mongbi_app/providers/dream_provider.dart';
+
+class DreamWritePage extends ConsumerStatefulWidget {
+  const DreamWritePage({super.key});
+
+  @override
+  ConsumerState<DreamWritePage> createState() => _DreamWritePageState();
+}
+
+class _DreamWritePageState extends ConsumerState<DreamWritePage> {
+  final FocusNode _focusNode = FocusNode();
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode.addListener(() {
+      ref
+          .read(dreamWriteViewModelProvider.notifier)
+          .setFocused(_focusNode.hasFocus);
+    });
+  }
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.grey[50],
+      resizeToAvoidBottomInset: true,
+      body: SafeArea(
+        child: GestureDetector(
+          onTap: () => FocusScope.of(context).unfocus(),
+          child: CustomScrollView(
+            slivers: [
+              SliverAppBar(
+                expandedHeight: 0,
+                backgroundColor: Colors.grey[50],
+                leading: IconButton(
+                  icon: Icon(Icons.arrow_back),
+                  onPressed: () {
+                    Navigator.pop(context);
+                  },
+                ),
+              ),
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // 꿈 내용 입력 필드
+                      Text('오늘 꿈 내용은', style: Font.title18),
+                      const SizedBox(height: 8),
+                      DreamContentInput(focusNode: _focusNode),
+                      const SizedBox(height: 72),
+
+                      // 기분 선택 아이콘 행 위젯
+                      Text('꿈을 꾸고 내 기분은', style: Font.title18),
+                      const SizedBox(height: 16),
+                      const MoodSelectionRow(),
+                      SizedBox(
+                        height:
+                            MediaQuery.of(context).viewInsets.bottom > 0
+                                ? 0
+                                : MediaQuery.of(context).size.height * 0.2,
+                      ),
+
+                      // 제출 버튼 위젯
+                      SubmitDreamButton(
+                        onSubmit: () {
+                          final notifier = ref.read(
+                            dreamWriteViewModelProvider.notifier,
+                          );
+                          final errorMessage = notifier.submitDream();
+
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(content: Text(errorMessage as String)),
+                          );
+                        },
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/dream/models/dream_write_state.dart
+++ b/lib/presentation/dream/models/dream_write_state.dart
@@ -1,0 +1,23 @@
+class DreamWriteState {
+  DreamWriteState({
+    this.dreamContent = '',
+    this.selectedIndex = -1,
+    this.isFocused = false,
+  });
+
+  final String dreamContent;
+  final int selectedIndex;
+  final bool isFocused;
+
+  DreamWriteState copyWith({
+    String? dreamContent,
+    int? selectedIndex,
+    bool? isFocused,
+  }) {
+    return DreamWriteState(
+      dreamContent: dreamContent ?? this.dreamContent,
+      selectedIndex: selectedIndex ?? this.selectedIndex,
+      isFocused: isFocused ?? this.isFocused,
+    );
+  }
+}

--- a/lib/presentation/dream/view_models/dream_write_view_model.dart
+++ b/lib/presentation/dream/view_models/dream_write_view_model.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mongbi_app/presentation/dream/models/dream_write_state.dart';
+
+class DreamWriteViewModel extends StateNotifier<DreamWriteState> {
+  DreamWriteViewModel() : super(DreamWriteState());
+
+  void setDreamContent(String content) {
+    state = state.copyWith(dreamContent: content);
+  }
+
+  void setSelectedIndex(int index) {
+    state = state.copyWith(selectedIndex: index);
+  }
+
+  void setFocused(bool focused) {
+    state = state.copyWith(isFocused: focused);
+  }
+
+  bool submitDream() {
+    // 텍스트 필드 내용이 10글자 미만인 경우
+    if (state.dreamContent.trim().length < 10) {
+      return false;
+    }
+    // 감정이 선택되지 않은 경우
+    if (state.selectedIndex == -1) {
+      return false;
+    }
+
+    // TODO: 꿈 해석 로직
+
+    return true;
+  }
+}
+

--- a/lib/presentation/dream/widgets/dream_content_input.dart
+++ b/lib/presentation/dream/widgets/dream_content_input.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mongbi_app/core/font.dart';
+import 'package:mongbi_app/providers/dream_provider.dart';
+
+class DreamContentInput extends ConsumerWidget {
+  const DreamContentInput({super.key, required this.focusNode});
+
+  final FocusNode focusNode;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(dreamWriteViewModelProvider);
+
+    return Container(
+      padding: const EdgeInsets.all(24),
+      decoration: BoxDecoration(
+        color: Colors.purple[50],
+        borderRadius: BorderRadius.circular(24),
+      ),
+      child: TextField(
+        focusNode: focusNode,
+        minLines: 9,
+        maxLines: null,
+        maxLength: 250,
+        onChanged: (text) {
+          ref.read(dreamWriteViewModelProvider.notifier).setDreamContent(text);
+        },
+        style: Font.subTitle14,
+        decoration: InputDecoration(
+          hintText: '오늘 꾼 꿈을 10글자 이상 입력해주몽 :)',
+          hintStyle: Font.subTitle14.copyWith(
+            color: state.isFocused ? Colors.grey : Colors.purple,
+          ),
+          border: InputBorder.none,
+          counter: Align(
+            alignment: Alignment.bottomRight,
+            child: Text(
+              '${state.dreamContent.length}/250',
+              style: Font.subTitle12.copyWith(color: Colors.grey),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/dream/widgets/mood_selection_row.dart
+++ b/lib/presentation/dream/widgets/mood_selection_row.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:mongbi_app/providers/dream_provider.dart';
+
+class MoodSelectionRow extends ConsumerWidget {
+  const MoodSelectionRow({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(dreamWriteViewModelProvider);
+
+    final iconNames = [
+      'assets/icons/very_bad.svg',
+      'assets/icons/bad.svg',
+      'assets/icons/ordinary.svg',
+      'assets/icons/good.svg',
+      'assets/icons/very_good.svg',
+    ];
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceAround,
+      children: List.generate(5, (index) {
+        return GestureDetector(
+          onTap: () {
+            ref.read(dreamWriteViewModelProvider.notifier).setSelectedIndex(index);
+          },
+          child: Opacity(
+            opacity: state.selectedIndex == index ? 1.0 : 0.2,
+            child: SvgPicture.asset(iconNames[index], width: 50, height: 50),
+          ),
+        );
+      }),
+    );
+  }
+}

--- a/lib/presentation/dream/widgets/submit_dream_button.dart
+++ b/lib/presentation/dream/widgets/submit_dream_button.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mongbi_app/core/font.dart';
+import 'package:mongbi_app/providers/dream_provider.dart';
+
+class SubmitDreamButton extends ConsumerWidget {
+  const SubmitDreamButton({super.key, required this.onSubmit});
+
+  final VoidCallback onSubmit;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(dreamWriteViewModelProvider);
+    final isButtonEnabled =
+        state.dreamContent.trim().length >= 10 && state.selectedIndex != -1;
+
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton(
+        onPressed: isButtonEnabled ? onSubmit : null,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: const Color(0xFF8C2EFF),
+          padding: const EdgeInsets.symmetric(vertical: 16),
+        ),
+        child: Text(
+          '내가 꾼 꿈이야',
+          style: Font.title18.copyWith(color: Colors.white),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/providers/dream_provider.dart
+++ b/lib/providers/dream_provider.dart
@@ -3,6 +3,8 @@ import 'package:mongbi_app/data/data_sources/dream_data_source.dart';
 import 'package:mongbi_app/data/data_sources/remote_dream_data_source.dart';
 import 'package:mongbi_app/data/repositories/remote_dream_repository.dart';
 import 'package:mongbi_app/domain/repositories/dream_repository.dart';
+import 'package:mongbi_app/presentation/dream/models/dream_write_state.dart';
+import 'package:mongbi_app/presentation/dream/view_models/dream_write_view_model.dart';
 import 'package:mongbi_app/providers/core_providers.dart';
 
 final _dreamDataSourceProvider = Provider<DreamDataSource>(
@@ -12,3 +14,8 @@ final _dreamDataSourceProvider = Provider<DreamDataSource>(
 final _dreamRepositoryProvider = Provider<DreamRepository>(
   (ref) => RemoteDreamRepository(ref.read(_dreamDataSourceProvider)),
 );
+
+final dreamWriteViewModelProvider =
+    StateNotifierProvider<DreamWriteViewModel, DreamWriteState>(
+      (ref) => DreamWriteViewModel(),
+    );


### PR DESCRIPTION
### 🚀 개요
- 꿈 작성 화면 UI 레이아웃 구현
- 꿈을 작성하는 TextField, 꿈을 꾸고 난 후 기분을 1점부터 5점까지 선택

### 🔧 작업 내용
- 꿈 작성 화면에서 관리하는 DreamWriteState 모델 구현
- DreamWriteViewModel 구현 (꿈 작성 내용, 이모티콘 선택, 텍스트필드 포커스 여부 관리)
- 꿈 작성 화면 UI 레이아웃 구현

### 📸 실행 화면
<img src="https://github.com/user-attachments/assets/ba9e1c0d-bc12-408a-abbb-3f1e9c2a8c6d" width="300" height="600"/>
<img src="https://github.com/user-attachments/assets/e41a4c99-26ed-4765-9fbb-89d38f4f4301" width="300" height="600"/>


### 💡 Issue
Closes #18 

