### PR TITLE
[Dream] 꿈 해석 UI 레이아웃 구현

### DIFF
--- a/lib/core/router.dart
+++ b/lib/core/router.dart
@@ -1,4 +1,5 @@
 import 'package:go_router/go_router.dart';
+import 'package:mongbi_app/presentation/auth/social_login_page.dart';
 import 'package:mongbi_app/presentation/dream/dream_analysis_loading_page.dart';
 import 'package:mongbi_app/presentation/dream/dream_analysis_result_page.dart';
 import 'package:mongbi_app/presentation/dream/dream_interpretation_page.dart';
@@ -7,7 +8,15 @@ import 'package:mongbi_app/presentation/dream/dream_write_page.dart';
 final GoRouter router = GoRouter(
   initialLocation: '/',
   routes: [
-    GoRoute(path: '/', builder: (context, state) => DreamWritePage()),
+    GoRoute(path: '/', builder: (context, state) => SocialLoginPage()),
+    GoRoute(
+      path: '/social_login',
+      builder: (context, state) => SocialLoginPage(),
+    ),
+    GoRoute(
+      path: '/dream_write',
+      builder: (context, state) => DreamWritePage(),
+    ),
     GoRoute(
       path: '/dream_analysis_loading',
       builder: (context, state) => DreamAnalysisLoadingPage(),

--- a/lib/core/router.dart
+++ b/lib/core/router.dart
@@ -1,0 +1,24 @@
+import 'package:go_router/go_router.dart';
+import 'package:mongbi_app/presentation/dream/dream_analysis_loading_page.dart';
+import 'package:mongbi_app/presentation/dream/dream_analysis_result_page.dart';
+import 'package:mongbi_app/presentation/dream/dream_interpretation_page.dart';
+import 'package:mongbi_app/presentation/dream/dream_write_page.dart';
+
+final GoRouter router = GoRouter(
+  initialLocation: '/',
+  routes: [
+    GoRoute(path: '/', builder: (context, state) => DreamWritePage()),
+    GoRoute(
+      path: '/dream_analysis_loading',
+      builder: (context, state) => DreamAnalysisLoadingPage(),
+    ),
+    GoRoute(
+      path: '/dream_analysis_result',
+      builder: (context, state) => DreamAnalysisResultPage(),
+    ),
+    GoRoute(
+      path: '/dream_interpretation',
+      builder: (context, state) => DreamInterpretationPage(),
+    ),
+  ],
+);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,8 +3,6 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:mongbi_app/core/router.dart';
-import 'package:mongbi_app/presentation/auth/social_login_page.dart';
-import 'package:mongbi_app/presentation/dream/dream_interpretation_page.dart';
 
 void main() async {
   await dotenv.load(fileName: '.env');

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/date_symbol_data_local.dart';
+import 'package:mongbi_app/core/router.dart';
 import 'package:mongbi_app/presentation/auth/social_login_page.dart';
+import 'package:mongbi_app/presentation/dream/dream_interpretation_page.dart';
 
 void main() async {
   await dotenv.load(fileName: '.env');
@@ -18,9 +20,9 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return MaterialApp.router(
+      routerConfig: router,
       theme: ThemeData(fontFamily: 'NanumSquareRound'),
-      home: SocialLoginPage(),
     );
   }
 }

--- a/lib/presentation/dream/dream_analysis_loading_page.dart
+++ b/lib/presentation/dream/dream_analysis_loading_page.dart
@@ -1,9 +1,26 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mongbi_app/core/font.dart';
 import 'package:mongbi_app/presentation/auth/widgets/mongbi_image_widget.dart';
+import 'package:mongbi_app/providers/dream_provider.dart';
 
-class DreamAnalysisLoadingPage extends StatelessWidget {
+class DreamAnalysisLoadingPage extends ConsumerStatefulWidget {
   const DreamAnalysisLoadingPage({super.key});
+
+  @override
+  ConsumerState<DreamAnalysisLoadingPage> createState() =>
+      _DreamAnalysisLoadingPageState();
+}
+
+class _DreamAnalysisLoadingPageState
+    extends ConsumerState<DreamAnalysisLoadingPage> {
+  @override
+  void initState() {
+    super.initState();
+
+    _analyzeDream();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -39,5 +56,21 @@ class DreamAnalysisLoadingPage extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  Future<void> _analyzeDream() async {
+    try {
+      await ref.read(dreamWriteViewModelProvider.notifier).submitDream();
+      if (mounted) {
+        context.go('/dream_analysis_result');
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('꿈 해석 중 오류가 발생했어요: $e')));
+        context.pop();
+      }
+    }
   }
 }

--- a/lib/presentation/dream/dream_analysis_loading_page.dart
+++ b/lib/presentation/dream/dream_analysis_loading_page.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:mongbi_app/core/font.dart';
+import 'package:mongbi_app/presentation/auth/widgets/mongbi_image_widget.dart';
+
+class DreamAnalysisLoadingPage extends StatelessWidget {
+  const DreamAnalysisLoadingPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [
+              Color(0xFFFBC8FF).withValues(alpha: 0.4),
+              Color(0xFFAE7CFF).withValues(alpha: 0.4),
+              Color(0xFF37DAFF).withValues(alpha: 0.4),
+            ],
+            stops: [0.0, 0.5, 1.0],
+          ),
+        ),
+        child: SafeArea(
+          child: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  '꿈 해석 중이야\n잠시만 기다려몽',
+                  textAlign: TextAlign.center,
+                  style: Font.title20,
+                ),
+                const SizedBox(height: 40),
+                MongbiCharacter(size: 288),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/dream/dream_analysis_result_page.dart
+++ b/lib/presentation/dream/dream_analysis_result_page.dart
@@ -1,9 +1,27 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mongbi_app/core/font.dart';
 import 'package:mongbi_app/presentation/auth/widgets/mongbi_image_widget.dart';
 
-class DreamAnalysisResultPage extends StatelessWidget {
+class DreamAnalysisResultPage extends StatefulWidget {
   const DreamAnalysisResultPage({super.key});
+
+  @override
+  State<DreamAnalysisResultPage> createState() =>
+      _DreamAnalysisResultPageState();
+}
+
+class _DreamAnalysisResultPageState extends State<DreamAnalysisResultPage> {
+  @override
+  void initState() {
+    super.initState();
+
+    Future.delayed(const Duration(seconds: 1), () {
+      if (mounted) {
+        context.go('/dream_interpretation');
+      }
+    });
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/presentation/dream/dream_analysis_result_page.dart
+++ b/lib/presentation/dream/dream_analysis_result_page.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:mongbi_app/core/font.dart';
+import 'package:mongbi_app/presentation/auth/widgets/mongbi_image_widget.dart';
+
+class DreamAnalysisResultPage extends StatelessWidget {
+  const DreamAnalysisResultPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [
+              Color(0xFFFFFDFF),
+              Color(0xFFEFD3FF),
+              Color(0xFFD1FFFD),
+            ],
+            stops: [0.0, 0.5, 1.0],
+          ),
+        ),
+        child: SafeArea(
+          child: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  '다됐다몽!\n',
+                  textAlign: TextAlign.center,
+                  style: Font.title20,
+                ),
+                const SizedBox(height: 40),
+                MongbiCharacter(size: 288),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/dream/dream_interpretation_page.dart
+++ b/lib/presentation/dream/dream_interpretation_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mongbi_app/core/font.dart';
 import 'package:mongbi_app/presentation/dream/widgets/custom_button.dart';
 import 'package:mongbi_app/presentation/dream/widgets/dream_section_card.dart';
 import 'package:mongbi_app/presentation/dream/widgets/mongbi_comment_card.dart';
@@ -50,8 +51,6 @@ class _DreamInterpretationPageState
                 CustomButton(
                   text: '다음',
                   onSubmit: () async {
-                    final scaffoldMessenger = ScaffoldMessenger.of(context);
-
                     try {
                       final isSuccess =
                           await ref
@@ -63,16 +62,10 @@ class _DreamInterpretationPageState
                       if (isSuccess) {
                         // TODO: 홈 화면으로 이동
                       } else {
-                        scaffoldMessenger.showSnackBar(
-                          const SnackBar(
-                            content: Text('꿈 저장에 실패했어요. 다시 시도해 주세요.'),
-                          ),
-                        );
+                        showSnackBar('꿈 저장에 실패했어요. 다시 시도해 주세요.');
                       }
                     } catch (e) {
-                      scaffoldMessenger.showSnackBar(
-                        SnackBar(content: Text('오류가 발생했어요: $e')),
-                      );
+                      showSnackBar('오류가 발생했어요: $e');
                     }
                   },
                 ),
@@ -84,5 +77,11 @@ class _DreamInterpretationPageState
         ),
       ),
     );
+  }
+
+  void showSnackBar(String message) {
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message, style: Font.body14)));
   }
 }

--- a/lib/presentation/dream/dream_interpretation_page.dart
+++ b/lib/presentation/dream/dream_interpretation_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:mongbi_app/presentation/dream/widgets/custom_button.dart';
 import 'package:mongbi_app/presentation/dream/widgets/dream_section_card.dart';
 import 'package:mongbi_app/presentation/dream/widgets/mongbi_comment_card.dart';
@@ -51,7 +50,6 @@ class _DreamInterpretationPageState
                 CustomButton(
                   text: '다음',
                   onSubmit: () async {
-                    final navigator = GoRouter.of(context);
                     final scaffoldMessenger = ScaffoldMessenger.of(context);
 
                     try {

--- a/lib/presentation/dream/dream_interpretation_page.dart
+++ b/lib/presentation/dream/dream_interpretation_page.dart
@@ -48,28 +48,7 @@ class _DreamInterpretationPageState
                   comment: dream.mongbiComment,
                 ),
                 SizedBox(height: 24),
-                CustomButton(
-                  text: '다음',
-                  onSubmit: () async {
-                    try {
-                      final isSuccess =
-                          await ref
-                              .read(
-                                dreamInterpretationViewModelProvider.notifier,
-                              )
-                              .saveDream();
-
-                      if (isSuccess) {
-                        // TODO: 홈 화면으로 이동
-                      } else {
-                        showSnackBar('꿈 저장에 실패했어요. 다시 시도해 주세요.');
-                      }
-                    } catch (e) {
-                      showSnackBar('오류가 발생했어요: $e');
-                    }
-                  },
-                ),
-
+                CustomButton(text: '다음', onSubmit: _onSubmitDream),
                 SizedBox(height: 24),
               ],
             ),
@@ -83,5 +62,22 @@ class _DreamInterpretationPageState
     ScaffoldMessenger.of(
       context,
     ).showSnackBar(SnackBar(content: Text(message, style: Font.body14)));
+  }
+
+  void _onSubmitDream() async {
+    try {
+      final isSuccess =
+          await ref
+              .read(dreamInterpretationViewModelProvider.notifier)
+              .saveDream();
+
+      if (isSuccess) {
+        // TODO: 홈 화면으로 이동
+      } else {
+        showSnackBar('꿈 저장에 실패했어요. 다시 시도해 주세요.');
+      }
+    } catch (e) {
+      showSnackBar('오류가 발생했어요: $e');
+    }
   }
 }

--- a/lib/presentation/dream/dream_interpretation_page.dart
+++ b/lib/presentation/dream/dream_interpretation_page.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mongbi_app/presentation/dream/widgets/custom_button.dart';
+import 'package:mongbi_app/presentation/dream/widgets/dream_section_card.dart';
+import 'package:mongbi_app/presentation/dream/widgets/mongbi_comment_card.dart';
+import 'package:mongbi_app/providers/dream_provider.dart';
+
+class DreamInterpretationPage extends ConsumerWidget {
+  const DreamInterpretationPage({super.key});
+
+  @override
+  Widget build(BuildContext context, ref) {
+    final dream = ref.watch(dreamInterpretationViewModelProvider);
+
+    return Scaffold(
+      appBar: AppBar(),
+      backgroundColor: Color(0xfffcf6ff),
+      body: SingleChildScrollView(
+        child: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            child: Column(
+              children: [
+                DreamSectionCard(
+                  title: '꿈을 해석 해보자면',
+                  subTitle: dream.dreamSubTitle,
+                  content: dream.dreamInterpretation,
+                  keywords: dream.dreamKeywords,
+                ),
+                SizedBox(height: 24),
+                DreamSectionCard(
+                  title: '심리 상태는',
+                  subTitle: dream.psychologicalSubTitle,
+                  content: dream.psychologicalStateInterpretation,
+                  keywords: dream.psychologicalStateKeywords,
+                ),
+                SizedBox(height: 24),
+                MongbiCommentCard(
+                  title: '몽비의 한마디',
+                  comment: dream.mongbiComment,
+                ),
+                SizedBox(height: 24),
+                CustomButton(
+                  text: '다음',
+                  onSubmit: () {
+                    // TODO: 다음 화면으로 이동
+                  },
+                ),
+                SizedBox(height: 24),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/dream/dream_interpretation_page.dart
+++ b/lib/presentation/dream/dream_interpretation_page.dart
@@ -1,15 +1,23 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mongbi_app/presentation/dream/widgets/custom_button.dart';
 import 'package:mongbi_app/presentation/dream/widgets/dream_section_card.dart';
 import 'package:mongbi_app/presentation/dream/widgets/mongbi_comment_card.dart';
 import 'package:mongbi_app/providers/dream_provider.dart';
 
-class DreamInterpretationPage extends ConsumerWidget {
+class DreamInterpretationPage extends ConsumerStatefulWidget {
   const DreamInterpretationPage({super.key});
 
   @override
-  Widget build(BuildContext context, ref) {
+  ConsumerState<DreamInterpretationPage> createState() =>
+      _DreamInterpretationPageState();
+}
+
+class _DreamInterpretationPageState
+    extends ConsumerState<DreamInterpretationPage> {
+  @override
+  Widget build(BuildContext context) {
     final dream = ref.watch(dreamInterpretationViewModelProvider);
 
     return Scaffold(
@@ -42,10 +50,35 @@ class DreamInterpretationPage extends ConsumerWidget {
                 SizedBox(height: 24),
                 CustomButton(
                   text: '다음',
-                  onSubmit: () {
-                    // TODO: 다음 화면으로 이동
+                  onSubmit: () async {
+                    final navigator = GoRouter.of(context);
+                    final scaffoldMessenger = ScaffoldMessenger.of(context);
+
+                    try {
+                      final isSuccess =
+                          await ref
+                              .read(
+                                dreamInterpretationViewModelProvider.notifier,
+                              )
+                              .saveDream();
+
+                      if (isSuccess) {
+                        // TODO: 홈 화면으로 이동
+                      } else {
+                        scaffoldMessenger.showSnackBar(
+                          const SnackBar(
+                            content: Text('꿈 저장에 실패했어요. 다시 시도해 주세요.'),
+                          ),
+                        );
+                      }
+                    } catch (e) {
+                      scaffoldMessenger.showSnackBar(
+                        SnackBar(content: Text('오류가 발생했어요: $e')),
+                      );
+                    }
                   },
                 ),
+
                 SizedBox(height: 24),
               ],
             ),

--- a/lib/presentation/dream/dream_write_page.dart
+++ b/lib/presentation/dream/dream_write_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mongbi_app/core/font.dart';
 import 'package:mongbi_app/presentation/dream/widgets/dream_content_input.dart';
 import 'package:mongbi_app/presentation/dream/widgets/mood_selection_row.dart';
@@ -78,9 +79,7 @@ class _DreamWritePageState extends ConsumerState<DreamWritePage> {
                       // 제출 버튼 위젯
                       SubmitDreamButton(
                         onSubmit: () {
-                          ref
-                              .read(dreamWriteViewModelProvider.notifier)
-                              .submitDream();
+                          context.go('/dream_analysis_loading');
                         },
                       ),
                     ],

--- a/lib/presentation/dream/models/dream_interpretation_state.dart
+++ b/lib/presentation/dream/models/dream_interpretation_state.dart
@@ -1,0 +1,19 @@
+class DreamInterpretationState {
+  DreamInterpretationState({
+    this.dreamSubTitle = '',
+    this.dreamInterpretation = '',
+    this.dreamKeywords = const [],
+    this.psychologicalSubTitle = '',
+    this.psychologicalStateInterpretation = '',
+    this.psychologicalStateKeywords = const [],
+    this.mongbiComment = '',
+  });
+
+  final String dreamSubTitle;
+  final String dreamInterpretation;
+  final List<String> dreamKeywords;
+  final String psychologicalSubTitle;
+  final String psychologicalStateInterpretation;
+  final List<String> psychologicalStateKeywords;
+  final String mongbiComment;
+}

--- a/lib/presentation/dream/models/dream_interpretation_state.dart
+++ b/lib/presentation/dream/models/dream_interpretation_state.dart
@@ -7,6 +7,7 @@ class DreamInterpretationState {
     this.psychologicalStateInterpretation = '',
     this.psychologicalStateKeywords = const [],
     this.mongbiComment = '',
+    this.dreamCategory = '',
   });
 
   final String dreamSubTitle;
@@ -16,4 +17,5 @@ class DreamInterpretationState {
   final String psychologicalStateInterpretation;
   final List<String> psychologicalStateKeywords;
   final String mongbiComment;
+  final String dreamCategory;
 }

--- a/lib/presentation/dream/view_models/dream_interpretation_view_model.dart
+++ b/lib/presentation/dream/view_models/dream_interpretation_view_model.dart
@@ -39,7 +39,6 @@ class DreamInterpretationViewModel extends Notifier<DreamInterpretationState> {
       dreamCategory: state.dreamCategory,
     );
 
-    final repository = ref.read(dreamRepositoryProvider);
-    return await repository.saveDream(dreamEntity);
+    return await ref.read(saveDreamUseCaseProvider).saveDream(dreamEntity);
   }
 }

--- a/lib/presentation/dream/view_models/dream_interpretation_view_model.dart
+++ b/lib/presentation/dream/view_models/dream_interpretation_view_model.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mongbi_app/domain/entities/dream.dart';
+import 'package:mongbi_app/presentation/dream/models/dream_interpretation_state.dart';
+
+class DreamInterpretationViewModel extends Notifier<DreamInterpretationState> {
+  @override
+  DreamInterpretationState build() {
+    return DreamInterpretationState();
+  }
+
+  void setDream(Dream dream) {
+    state = DreamInterpretationState(
+      dreamSubTitle: dream.dreamSubTitle,
+      dreamInterpretation: dream.dreamInterpretation,
+      dreamKeywords: dream.dreamKeywords,
+      psychologicalSubTitle: dream.psychologicalSubTitle,
+      psychologicalStateInterpretation: dream.psychologicalStateInterpretation,
+      psychologicalStateKeywords: dream.psychologicalStateKeywords,
+      mongbiComment: dream.mongbiComment,
+    );
+  }
+}

--- a/lib/presentation/dream/view_models/dream_interpretation_view_model.dart
+++ b/lib/presentation/dream/view_models/dream_interpretation_view_model.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mongbi_app/domain/entities/dream.dart';
 import 'package:mongbi_app/presentation/dream/models/dream_interpretation_state.dart';
+import 'package:mongbi_app/providers/dream_provider.dart';
 
 class DreamInterpretationViewModel extends Notifier<DreamInterpretationState> {
   @override
@@ -18,5 +19,27 @@ class DreamInterpretationViewModel extends Notifier<DreamInterpretationState> {
       psychologicalStateKeywords: dream.psychologicalStateKeywords,
       mongbiComment: dream.mongbiComment,
     );
+  }
+
+  Future<bool> saveDream() async {
+    final dreamWriteState = ref.read(dreamWriteViewModelProvider);
+    final dreamEntity = Dream(
+      createdAt: DateTime.now(),
+      uid: 4, // TODO: 실제 로그인 사용자 ID로 교체
+      challengeId: 0, // TODO: 실제 챌린지 ID로 교체
+      content: dreamWriteState.dreamContent,
+      score: dreamWriteState.selectedIndex,
+      dreamKeywords: state.dreamKeywords,
+      dreamSubTitle: state.dreamSubTitle,
+      dreamInterpretation: state.dreamInterpretation,
+      psychologicalSubTitle: state.psychologicalSubTitle,
+      psychologicalStateInterpretation: state.psychologicalStateInterpretation,
+      psychologicalStateKeywords: state.psychologicalStateKeywords,
+      mongbiComment: state.mongbiComment,
+      dreamCategory: state.dreamCategory,
+    );
+
+    final repository = ref.read(dreamRepositoryProvider);
+    return await repository.saveDream(dreamEntity);
   }
 }

--- a/lib/presentation/dream/view_models/dream_write_view_model.dart
+++ b/lib/presentation/dream/view_models/dream_write_view_model.dart
@@ -20,20 +20,13 @@ class DreamWriteViewModel extends Notifier<DreamWriteState> {
     state = state.copyWith(isFocused: focused);
   }
 
-  bool submitDream() {
-    // 텍스트 필드 내용이 10글자 미만인 경우
-    if (state.dreamContent.trim().length < 10) {
-      return false;
-    }
-    // 감정이 선택되지 않은 경우
-    if (state.selectedIndex == -1) {
-      return false;
-    }
+  Future<void> submitDream() async {
+    if (state.dreamContent.trim().length < 10) return;
+    if (state.selectedIndex == -1) return;
 
-    ref
+    final dream = await ref
         .read(analyzeDreamUseCaseProvider)
         .execute(state.dreamContent, state.selectedIndex);
-
-    return true;
+    ref.read(dreamInterpretationViewModelProvider.notifier).setDream(dream);
   }
 }

--- a/lib/presentation/dream/widgets/custom_button.dart
+++ b/lib/presentation/dream/widgets/custom_button.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:mongbi_app/core/font.dart';
+
+class CustomButton extends StatelessWidget {
+  const CustomButton({super.key, required this.text, required this.onSubmit});
+
+  final String text;
+  final VoidCallback onSubmit;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 56,
+      width: double.infinity,
+      child: ElevatedButton(
+        onPressed: onSubmit,
+        style: ButtonStyle(
+          backgroundColor: WidgetStateProperty.all(Color(0xff8c2eff)),
+        ),
+        child: Text(text, style: Font.title18.copyWith(color: Colors.white)),
+      ),
+    );
+  }
+}

--- a/lib/presentation/dream/widgets/dream_section_card.dart
+++ b/lib/presentation/dream/widgets/dream_section_card.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:mongbi_app/core/font.dart';
+
+class DreamSectionCard extends StatelessWidget {
+  const DreamSectionCard({
+    super.key,
+    required this.title,
+    required this.subTitle,
+    required this.content,
+    required this.keywords,
+  });
+
+  final String title;
+  final String subTitle;
+  final String content;
+  final List<String> keywords;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(title, style: Font.title18),
+        SizedBox(height: 8),
+        Container(
+          padding: EdgeInsets.all(24),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(24),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(subTitle, style: Font.subTitle16),
+              SizedBox(height: 16),
+              Text(
+                content,
+                style: Font.body14.copyWith(color: Colors.grey[900]),
+              ),
+              SizedBox(height: 16),
+              SizedBox(
+                height: 34,
+                child: ListView.builder(
+                  itemCount: keywords.length,
+                  scrollDirection: Axis.horizontal,
+                  itemBuilder:
+                      (context, index) => Container(
+                        padding: EdgeInsets.all(8),
+                        decoration: BoxDecoration(
+                          color: Colors.grey[100],
+                          borderRadius: BorderRadius.circular(999),
+                        ),
+                        child: Text(
+                          keywords[index],
+                          style: Font.body12.copyWith(color: Colors.grey[600]),
+                        ),
+                      ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/dream/widgets/dream_section_card.dart
+++ b/lib/presentation/dream/widgets/dream_section_card.dart
@@ -40,9 +40,10 @@ class DreamSectionCard extends StatelessWidget {
               SizedBox(height: 16),
               SizedBox(
                 height: 34,
-                child: ListView.builder(
+                child: ListView.separated(
                   itemCount: keywords.length,
                   scrollDirection: Axis.horizontal,
+                  separatorBuilder: (context, index) => SizedBox(width: 8),
                   itemBuilder:
                       (context, index) => Container(
                         padding: EdgeInsets.all(8),
@@ -51,7 +52,7 @@ class DreamSectionCard extends StatelessWidget {
                           borderRadius: BorderRadius.circular(999),
                         ),
                         child: Text(
-                          keywords[index],
+                          '#${keywords[index]}',
                           style: Font.body12.copyWith(color: Colors.grey[600]),
                         ),
                       ),

--- a/lib/presentation/dream/widgets/mongbi_comment_card.dart
+++ b/lib/presentation/dream/widgets/mongbi_comment_card.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:mongbi_app/core/font.dart';
+
+class MongbiCommentCard extends StatelessWidget {
+  const MongbiCommentCard({
+    super.key,
+    required this.title,
+    required this.comment,
+  });
+
+  final String title;
+  final String comment;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(title, style: Font.title18),
+        SizedBox(height: 9),
+        Container(
+          padding: EdgeInsets.all(24),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(24),
+          ),
+          child: Text(
+            comment,
+            style: Font.body14.copyWith(color: Colors.grey[900]),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/providers/core_providers.dart
+++ b/lib/providers/core_providers.dart
@@ -3,5 +3,13 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final dioProvider = Provider<Dio>(
-  (ref) => Dio(BaseOptions(baseUrl: dotenv.env['MONGBI_BASE_URL']!)),
+  (ref) => Dio(
+    BaseOptions(
+      baseUrl: dotenv.env['MONGBI_BASE_URL']!,
+      headers: {
+        'Authorization': 'Bearer ${dotenv.env['BEARER_KEY']}',
+        'Content-Type': 'application/json',
+      },
+    ),
+  ),
 );

--- a/lib/providers/dream_provider.dart
+++ b/lib/providers/dream_provider.dart
@@ -7,6 +7,7 @@ import 'package:mongbi_app/data/data_sources/remote_dream_data_source.dart';
 import 'package:mongbi_app/data/repositories/remote_dream_repository.dart';
 import 'package:mongbi_app/domain/repositories/dream_repository.dart';
 import 'package:mongbi_app/domain/use_cases/analyze_dream_use_case.dart';
+import 'package:mongbi_app/domain/use_cases/dream_save_use_case.dart';
 import 'package:mongbi_app/presentation/dream/models/dream_interpretation_state.dart';
 import 'package:mongbi_app/presentation/dream/models/dream_write_state.dart';
 import 'package:mongbi_app/presentation/dream/view_models/dream_interpretation_view_model.dart';
@@ -26,15 +27,19 @@ final _dreamAnalysisDataSource = Provider<DreamAnalysisDataSource>(
   ),
 );
 
-final analyzeDreamUseCaseProvider = Provider<AnalyzeDreamUseCase>(
-  (ref) => AnalyzeDreamUseCase(ref.read(_dreamRepositoryProvider)),
-);
-
 final _dreamRepositoryProvider = Provider<DreamRepository>(
   (ref) => RemoteDreamRepository(
     ref.read(_dreamDataSourceProvider),
     ref.read(_dreamAnalysisDataSource),
   ),
+);
+
+final analyzeDreamUseCaseProvider = Provider<AnalyzeDreamUseCase>(
+  (ref) => AnalyzeDreamUseCase(ref.read(_dreamRepositoryProvider)),
+);
+
+final saveDreamUseCaseProvider = Provider<DreamSaveUseCase>(
+  (ref) => DreamSaveUseCase(ref.read(_dreamRepositoryProvider)),
 );
 
 final dreamWriteViewModelProvider =

--- a/lib/providers/dream_provider.dart
+++ b/lib/providers/dream_provider.dart
@@ -7,7 +7,9 @@ import 'package:mongbi_app/data/data_sources/remote_dream_data_source.dart';
 import 'package:mongbi_app/data/repositories/remote_dream_repository.dart';
 import 'package:mongbi_app/domain/repositories/dream_repository.dart';
 import 'package:mongbi_app/domain/use_cases/analyze_dream_use_case.dart';
+import 'package:mongbi_app/presentation/dream/models/dream_interpretation_state.dart';
 import 'package:mongbi_app/presentation/dream/models/dream_write_state.dart';
+import 'package:mongbi_app/presentation/dream/view_models/dream_interpretation_view_model.dart';
 import 'package:mongbi_app/presentation/dream/view_models/dream_write_view_model.dart';
 import 'package:mongbi_app/providers/core_providers.dart';
 
@@ -38,4 +40,9 @@ final _dreamRepositoryProvider = Provider<DreamRepository>(
 final dreamWriteViewModelProvider =
     NotifierProvider<DreamWriteViewModel, DreamWriteState>(
       () => DreamWriteViewModel(),
+    );
+
+final dreamInterpretationViewModelProvider =
+    NotifierProvider<DreamInterpretationViewModel, DreamInterpretationState>(
+      () => DreamInterpretationViewModel(),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -85,7 +85,7 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
@@ -152,6 +152,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      sha256: b453934c36e289cef06525734d1e676c1f91da9e22e2017d9dcab6ce0f999175
+      url: "https://pub.dev"
+    source: hosted
+    version: "15.1.3"
   http:
     dependency: transitive
     description:
@@ -180,10 +188,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -208,6 +216,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
@@ -497,10 +513,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "14.3.1"
   web:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   assorted_layout_widgets: ^11.0.0
   flutter_dotenv: ^5.2.1
   shared_preferences: ^2.5.3
+  go_router: ^15.1.3
 
 dev_dependencies:
   flutter_test:

--- a/test/presentation/dream_interpretation_view_model_test.dart
+++ b/test/presentation/dream_interpretation_view_model_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:mongbi_app/domain/entities/dream.dart';
+import 'package:mongbi_app/domain/repositories/dream_repository.dart';
+import 'package:mongbi_app/presentation/dream/view_models/dream_interpretation_view_model.dart';
+import 'package:mongbi_app/providers/dream_provider.dart';
+
+void main() {
+  late ProviderContainer container;
+  late DreamInterpretationViewModel viewModel;
+  late MockDreamRepository mockDreamRepository;
+
+  setUpAll(() {
+    registerFallbackValue(FakeDream());
+  });
+
+  setUp(() {
+    mockDreamRepository = MockDreamRepository();
+
+    container = ProviderContainer(
+      overrides: [
+        dreamRepositoryProvider.overrideWithValue(mockDreamRepository),
+      ],
+    );
+
+    viewModel = container.read(dreamInterpretationViewModelProvider.notifier);
+  });
+
+  tearDown(() {
+    container.dispose();
+  });
+
+  group('DreamInterpretationViewModel saveDream Test', () {
+    test('saveDream이 성공하면 true 반환', () async {
+      // Arrange
+      when(
+        () => mockDreamRepository.saveDream(any()),
+      ).thenAnswer((_) async => true);
+
+      viewModel.setDream(
+        Dream(
+          createdAt: DateTime.now(),
+          uid: 4,
+          challengeId: 0,
+          content: '',
+          score: 1,
+          dreamKeywords: ['테스트'],
+          dreamSubTitle: '테스트 해석',
+          dreamInterpretation: '테스트 해몽',
+          psychologicalSubTitle: '테스트 심리',
+          psychologicalStateInterpretation: '심리상태 테스트',
+          psychologicalStateKeywords: ['심리'],
+          mongbiComment: '몽비 코멘트',
+          dreamCategory: '길몽',
+        ),
+      );
+
+      // Act
+      final result = await viewModel.saveDream();
+
+      // Assert
+      expect(result, true);
+      verify(() => mockDreamRepository.saveDream(any())).called(1);
+    });
+
+    test('saveDream이 실패하면 false 반환', () async {
+      // Arrange
+      when(
+        () => mockDreamRepository.saveDream(any()),
+      ).thenAnswer((_) async => false);
+
+      viewModel.setDream(
+        Dream(
+          createdAt: DateTime.now(),
+          uid: 4,
+          challengeId: 0,
+          content: '',
+          score: 1,
+          dreamKeywords: ['테스트'],
+          dreamSubTitle: '테스트 해석',
+          dreamInterpretation: '테스트 해몽',
+          psychologicalSubTitle: '테스트 심리',
+          psychologicalStateInterpretation: '심리상태 테스트',
+          psychologicalStateKeywords: ['심리'],
+          mongbiComment: '몽비 코멘트',
+          dreamCategory: '길몽',
+        ),
+      );
+
+      // Act
+      final result = await viewModel.saveDream();
+
+      // Assert
+      expect(result, false);
+      verify(() => mockDreamRepository.saveDream(any())).called(1);
+    });
+  });
+}
+
+class MockDreamRepository extends Mock implements DreamRepository {}
+
+class FakeDream extends Fake implements Dream {}

--- a/test/presentation/dream_interpretation_view_model_test.dart
+++ b/test/presentation/dream_interpretation_view_model_test.dart
@@ -2,25 +2,25 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:mongbi_app/domain/entities/dream.dart';
-import 'package:mongbi_app/domain/repositories/dream_repository.dart';
+import 'package:mongbi_app/domain/use_cases/dream_save_use_case.dart';
 import 'package:mongbi_app/presentation/dream/view_models/dream_interpretation_view_model.dart';
 import 'package:mongbi_app/providers/dream_provider.dart';
 
 void main() {
   late ProviderContainer container;
   late DreamInterpretationViewModel viewModel;
-  late MockDreamRepository mockDreamRepository;
+  late MockDreamSaveUseCase mockDreamSaveUseCase;
 
   setUpAll(() {
     registerFallbackValue(FakeDream());
   });
 
   setUp(() {
-    mockDreamRepository = MockDreamRepository();
+    mockDreamSaveUseCase = MockDreamSaveUseCase();
 
     container = ProviderContainer(
       overrides: [
-        dreamRepositoryProvider.overrideWithValue(mockDreamRepository),
+        saveDreamUseCaseProvider.overrideWithValue(mockDreamSaveUseCase),
       ],
     );
 
@@ -35,7 +35,7 @@ void main() {
     test('saveDream이 성공하면 true 반환', () async {
       // Arrange
       when(
-        () => mockDreamRepository.saveDream(any()),
+        () => mockDreamSaveUseCase.saveDream(any()),
       ).thenAnswer((_) async => true);
 
       viewModel.setDream(
@@ -61,13 +61,13 @@ void main() {
 
       // Assert
       expect(result, true);
-      verify(() => mockDreamRepository.saveDream(any())).called(1);
+      verify(() => mockDreamSaveUseCase.saveDream(any())).called(1);
     });
 
     test('saveDream이 실패하면 false 반환', () async {
       // Arrange
       when(
-        () => mockDreamRepository.saveDream(any()),
+        () => mockDreamSaveUseCase.saveDream(any()),
       ).thenAnswer((_) async => false);
 
       viewModel.setDream(
@@ -93,11 +93,11 @@ void main() {
 
       // Assert
       expect(result, false);
-      verify(() => mockDreamRepository.saveDream(any())).called(1);
+      verify(() => mockDreamSaveUseCase.saveDream(any())).called(1);
     });
   });
 }
 
-class MockDreamRepository extends Mock implements DreamRepository {}
+class MockDreamSaveUseCase extends Mock implements DreamSaveUseCase {}
 
 class FakeDream extends Fake implements Dream {}


### PR DESCRIPTION
### 🚀 개요
- 꿈 해석 UI 구현
- ai 응답을 기다릴 동안 대기 화면 구현

### 🔧 작업 내용
- GoRouter 경로 설정
- 꿈 대기 화면 구현
- 꿈 대기 완료 화면 구현
- 꿈 해석 화면 구현
- 꿈 해석 ViewModel, Model 구현
- 꿈 저장 로직 구현

### 📸 실행 화면
<img src="https://github.com/user-attachments/assets/8bab751f-975b-464b-a422-9650e688e272" width="300" height="600"/>
<img src="https://github.com/user-attachments/assets/6107e1b0-95b9-454b-91e9-9125d14af760" width="300" height="600"/>
<img src="https://github.com/user-attachments/assets/dd80a963-5fca-43bd-93e3-63bc7f888e49" width="300" height="600"/>

### 💡 Issue
Closes #28 

