### PR TITLE
[Dream] 꿈 작성 전 화면 생성

### DIFF
--- a/lib/core/main_scaffold.dart
+++ b/lib/core/main_scaffold.dart
@@ -48,7 +48,7 @@ class MainScaffold extends StatelessWidget {
               isHistory,
             ),
             GestureDetector(
-              onTap: () => context.push('/dream_write'),
+              onTap: () => context.push('/dream_intro'),
               child: Container(
                 width: 48,
                 height: 48,

--- a/lib/core/router.dart
+++ b/lib/core/router.dart
@@ -5,6 +5,7 @@ import 'package:mongbi_app/presentation/auth/social_login_page.dart';
 import 'package:mongbi_app/presentation/dream/dream_analysis_loading_page.dart';
 import 'package:mongbi_app/presentation/dream/dream_analysis_result_page.dart';
 import 'package:mongbi_app/presentation/dream/dream_interpretation_page.dart';
+import 'package:mongbi_app/presentation/dream/dream_intro_page.dart';
 import 'package:mongbi_app/presentation/dream/dream_write_page.dart';
 import 'package:mongbi_app/presentation/history/history_page.dart';
 import 'package:mongbi_app/presentation/home/home_page.dart';
@@ -45,6 +46,14 @@ final GoRouter router = GoRouter(
     GoRoute(
       path: '/nickname_input',
       builder: (context, state) => NicknameInputPage(),
+    ),
+    GoRoute(
+      path: '/dream_intro',
+      pageBuilder:
+          (context, state) => buildFadeTransitionPage(
+            key: state.pageKey,
+            child: DreamIntroPage(),
+          ),
     ),
     GoRoute(
       path: '/dream_write',

--- a/lib/presentation/dream/dream_analysis_loading_page.dart
+++ b/lib/presentation/dream/dream_analysis_loading_page.dart
@@ -53,7 +53,7 @@ class _DreamAnalysisLoadingPageState
                 const SizedBox(height: 40),
                 FloatingAnimationWidget(
                   child: Image.asset(
-                    'assets/images/splash_mongbi.png',
+                    'assets/images/splash_mongbi.webp',
                     width: screenHeight * 0.28,
                     height: screenHeight * 0.28,
                   ),

--- a/lib/presentation/dream/dream_analysis_result_page.dart
+++ b/lib/presentation/dream/dream_analysis_result_page.dart
@@ -50,7 +50,7 @@ class _DreamAnalysisResultPageState extends State<DreamAnalysisResultPage> {
                 const SizedBox(height: 40),
                 FloatingAnimationWidget(
                   child: Image.asset(
-                    'assets/images/splash_mongbi.png',
+                    'assets/images/splash_mongbi.webp',
                     width: screenHeight * 0.28,
                     height: screenHeight * 0.28,
                   ),

--- a/lib/presentation/dream/dream_intro_page.dart
+++ b/lib/presentation/dream/dream_intro_page.dart
@@ -17,7 +17,7 @@ class _DreamAnalysisResultPageState extends State<DreamIntroPage> {
 
     Future.delayed(const Duration(milliseconds: 1500), () {
       if (mounted) {
-        context.go('/dream_write');
+        context.pushReplacement('/dream_write');
       }
     });
   }

--- a/lib/presentation/dream/dream_intro_page.dart
+++ b/lib/presentation/dream/dream_intro_page.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mongbi_app/core/font.dart';
+import 'package:mongbi_app/presentation/common/floating_animation_widget.dart';
+
+class DreamIntroPage extends StatefulWidget {
+  const DreamIntroPage({super.key});
+
+  @override
+  State<DreamIntroPage> createState() => _DreamAnalysisResultPageState();
+}
+
+class _DreamAnalysisResultPageState extends State<DreamIntroPage> {
+  @override
+  void initState() {
+    super.initState();
+
+    Future.delayed(const Duration(milliseconds: 1500), () {
+      if (mounted) {
+        context.go('/dream_write');
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final screenHeight = MediaQuery.of(context).size.height;
+
+    return Scaffold(
+      body: Container(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [Color(0xFFFFFDFF), Color(0xFFEFD3FF), Color(0xFFD1FFFD)],
+            stops: [0.0, 0.5, 1.0],
+          ),
+        ),
+        child: SafeArea(
+          child: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  '오늘은 어떤 꿈을 꿨몽?\n',
+                  textAlign: TextAlign.center,
+                  style: Font.title20,
+                ),
+                const SizedBox(height: 40),
+                FloatingAnimationWidget(
+                  child: Image.asset(
+                    'assets/images/splash_mongbi.webp',
+                    width: screenHeight * 0.28,
+                    height: screenHeight * 0.28,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### 🚀 개요
- 홈 화면에서 꿈 작성 화면으로 이동하는 버튼을 클릭할 때
- 꿈 작성 화면으로 이동하기 전 어떤 꿈을 꿨냐는 대기 화면 생성
- 부드럽게 넘어갈 수 있도록 페이지 Fade in / Fade out 애니메이션 적용 

### 🔧 작업 내용
- 꿈 작성 인트로 화면 구현
-  페이지 부드럽게 이동할 수 있도록 애니메이션 적용

### 📸 실행 화면
<img src="https://github.com/user-attachments/assets/b9d14db2-f436-434e-9f3b-61d3cc678031" width="300" height="600"/>


### 💡 Issue
Closes #59

