### PR TITLE
[Dream] 사용자 ID 연결

### DIFF
--- a/lib/data/repositories/remote_dream_repository.dart
+++ b/lib/data/repositories/remote_dream_repository.dart
@@ -17,7 +17,7 @@ class RemoteDreamRepository implements DreamRepository {
   }
 
   @override
-  Future<Dream> analyzeDream(String dreamContent, int dreamScore) async {
+  Future<Dream> analyzeDream(int uid, String dreamContent, int dreamScore) async {
     final responseMap = await dreamAnalysisDataSource.analyzeDream(
       dreamContent,
       dreamScore,
@@ -26,7 +26,7 @@ class RemoteDreamRepository implements DreamRepository {
     final dream = Dream(
       id: null, // TODO: 저장한 후, Dream Id로 저장
       createdAt: DateTime.now(),
-      uid: 1, // TODO: 사용자 id로 변경
+      uid: uid,
       challengeId: 0, // TODO: 사용자가 선택한 챌린지 id로 변경
       content: dreamContent,
       score: dreamScore,

--- a/lib/domain/repositories/dream_repository.dart
+++ b/lib/domain/repositories/dream_repository.dart
@@ -3,5 +3,5 @@ import 'package:mongbi_app/domain/entities/dream.dart';
 abstract interface class DreamRepository {
   Future<bool> saveDream(Dream dream);
 
-  Future<Dream> analyzeDream(String dreamContent, int dreamScore);
+  Future<Dream> analyzeDream(int uid, String dreamContent, int dreamScore);
 }

--- a/lib/domain/use_cases/analyze_and_save_dream_use_case.dart
+++ b/lib/domain/use_cases/analyze_and_save_dream_use_case.dart
@@ -8,9 +8,9 @@ class AnalyzeAndSaveDreamUseCase {
   final AnalyzeDreamUseCase analyzeDreamUseCase;
   final SaveDreamUseCase saveDreamUseCase;
 
-  Future<Dream> execute(String dreamContent, int dreamScore) async {
-    final dream = await analyzeDreamUseCase.execute(dreamContent, dreamScore);
-    await saveDreamUseCase.execute(dream);
+  Future<Dream> execute(int uid, String dreamContent, int dreamScore) async {
+    final dream = await analyzeDreamUseCase.execute(uid, dreamContent, dreamScore);
+    await saveDreamUseCase.execute(uid, dream);
     return dream;
   }
 }

--- a/lib/domain/use_cases/analyze_dream_use_case.dart
+++ b/lib/domain/use_cases/analyze_dream_use_case.dart
@@ -6,7 +6,7 @@ class AnalyzeDreamUseCase {
 
   final DreamRepository dreamRepository;
 
-  Future<Dream> execute(String dreamContent, int dreamScore) async {
-    return await dreamRepository.analyzeDream(dreamContent, dreamScore);
+  Future<Dream> execute(int uid, String dreamContent, int dreamScore) async {
+    return await dreamRepository.analyzeDream(uid, dreamContent, dreamScore);
   }
 }

--- a/lib/domain/use_cases/save_dream_use_case.dart
+++ b/lib/domain/use_cases/save_dream_use_case.dart
@@ -6,7 +6,7 @@ class SaveDreamUseCase {
 
   final DreamRepository dreamRepository;
 
-  Future<bool> execute(Dream dream) async {
+  Future<bool> execute(int uid, Dream dream) async {
     return await dreamRepository.saveDream(dream);
   }
 }

--- a/lib/presentation/dream/view_models/dream_write_view_model.dart
+++ b/lib/presentation/dream/view_models/dream_write_view_model.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mongbi_app/presentation/dream/models/dream_write_state.dart';
+import 'package:mongbi_app/providers/auth_provider.dart';
 import 'package:mongbi_app/providers/dream_provider.dart';
 
 class DreamWriteViewModel extends Notifier<DreamWriteState> {
@@ -23,10 +24,13 @@ class DreamWriteViewModel extends Notifier<DreamWriteState> {
   Future<void> submitDream() async {
     if (state.dreamContent.trim().length < 10) return;
     if (state.selectedIndex == -1) return;
+    final user = ref.read(authViewModelProvider);
+
+    if (user == null) return;
 
     final dream = await ref
         .read(analyzeAndSaveDreamUseCaseProvider)
-        .execute(state.dreamContent, state.selectedIndex);
+        .execute(user.userIdx, state.dreamContent, state.selectedIndex);
     ref.read(dreamInterpretationViewModelProvider.notifier).setDream(dream);
   }
 }


### PR DESCRIPTION
### 🚀 개요
- 로그인한 사용자의 id 연결

### 🔧 작업 내용
- 로그인한 사용자의 데이터를 ref.read(authViewModelProvider)로 불러와서 uid를 전달
- 꿈 해석과 함께 전달받은 uid를 같이 저장

### 💡 Issue
Closes #43 