### PR TITLE
[Statistics] SliverAppBar 오류 수정

### DIFF
--- a/lib/presentation/statistics/statistics_page.dart
+++ b/lib/presentation/statistics/statistics_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mongbi_app/core/font.dart';
+import 'package:mongbi_app/core/get_responsive_ratio_by_width.dart';
 import 'package:mongbi_app/presentation/statistics/widgets/month_statistics.dart';
 import 'package:mongbi_app/presentation/statistics/widgets/tab_bar_title.dart';
 import 'package:mongbi_app/presentation/statistics/widgets/year_statistics.dart';
@@ -16,6 +17,10 @@ class _StatisticsPageState extends State<StatisticsPage> {
 
   @override
   Widget build(BuildContext context) {
+    final double tabBarHeight =
+        getResponsiveRatioByWidth(context, 48) + // TabBar 높이
+        getResponsiveRatioByWidth(context, 8) * 2; // Padding Vertical
+
     return Stack(
       children: [
         Container(
@@ -50,6 +55,7 @@ class _StatisticsPageState extends State<StatisticsPage> {
                     pinned: true,
                     delegate: _SliverTabBarDelegate(
                       TabBarTitle(horizontalPadding: horizontalPadding),
+                      tabBarHeight,
                     ),
                   ),
                 ];
@@ -69,14 +75,15 @@ class _StatisticsPageState extends State<StatisticsPage> {
 }
 
 class _SliverTabBarDelegate extends SliverPersistentHeaderDelegate {
-  _SliverTabBarDelegate(this.tabBar);
+  _SliverTabBarDelegate(this.tabBar, this.height);
 
-  final PreferredSizeWidget tabBar;
+  final Widget tabBar;
+  final double height;
 
   @override
-  double get minExtent => tabBar.preferredSize.height;
+  double get minExtent => height;
   @override
-  double get maxExtent => tabBar.preferredSize.height;
+  double get maxExtent => height;
 
   @override
   Widget build(

--- a/lib/presentation/statistics/widgets/tab_bar_title.dart
+++ b/lib/presentation/statistics/widgets/tab_bar_title.dart
@@ -4,13 +4,10 @@ import 'package:mongbi_app/core/font.dart';
 import 'package:mongbi_app/core/get_responsive_ratio_by_width.dart';
 import 'package:mongbi_app/providers/statistics_provider.dart';
 
-class TabBarTitle extends StatelessWidget implements PreferredSizeWidget {
+class TabBarTitle extends StatelessWidget {
   const TabBarTitle({super.key, required this.horizontalPadding});
 
   final double horizontalPadding;
-
-  @override
-  Size get preferredSize => const Size.fromHeight(70); // 원하는 높이로 조절
 
   @override
   Widget build(BuildContext context) {
@@ -32,6 +29,7 @@ class TabBarTitle extends StatelessWidget implements PreferredSizeWidget {
 
             return TabBar(
               onTap: (value) {
+                ScaffoldMessenger.of(context).hideCurrentSnackBar();
                 if (value == 0) {
                   statisticsVm.fetchMonthStatistics();
                 } else {


### PR DESCRIPTION
### 🚀 개요
기기별 크기에 대응하지 못하고 넘쳐서 생긴 렌더링 오류 해결

### 🔧 작업 내용
- getResponsiveRatioByWidth를 사용하여 디자인상 탭바의 높이 + 패딩 상하*2를 높이로 할당하여 해결

### 💡 Issue
Closes #84 

