### PR TITLE
[Statistics] 해당 월별/년도별 통계 자료가 없을 경우 꿈 작성 페이지로 유도하는 스낵바 표시

### DIFF
--- a/lib/core/main_scaffold.dart
+++ b/lib/core/main_scaffold.dart
@@ -58,7 +58,7 @@ class MainScaffold extends StatelessWidget {
                   gradient: LinearGradient(
                     begin: Alignment.topLeft,
                     end: Alignment.bottomRight,
-                    stops: isHistory? [0.1, 1.0] : [0, 1.0],
+                    stops: isHistory ? [0.1, 1.0] : [0, 1.0],
                     colors:
                         isHistory
                             ? [Color(0xFFEAC9FA), Color(0xFF8C2EFF)]
@@ -148,7 +148,10 @@ class MainScaffold extends StatelessWidget {
     final stateSuffix = selected ? 'filled' : 'outlined';
 
     return GestureDetector(
-      onTap: () => context.go(path),
+      onTap: () {
+        ScaffoldMessenger.of(context).hideCurrentSnackBar();
+        context.go(path);
+      },
       child: SvgPicture.asset(
         'assets/icons/$iconName${colorSuffix}_$stateSuffix.svg',
         width: 28,

--- a/lib/presentation/statistics/statistics_key/statistics_key.dart
+++ b/lib/presentation/statistics/statistics_key/statistics_key.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mongbi_app/presentation/statistics/widgets/custom_snack_bar.dart';
 import 'package:mongbi_app/presentation/statistics/widgets/month_year_picker.dart';
 
 final monthPickerButton = GlobalKey();
@@ -7,3 +8,7 @@ final GlobalKey<MonthYearPickerState> monthPickerKey =
     GlobalKey<MonthYearPickerState>();
 final GlobalKey<MonthYearPickerState> yearPickerKey =
     GlobalKey<MonthYearPickerState>();
+final GlobalKey<CustomSnackBarState> monthSnackBarKey =
+    GlobalKey<CustomSnackBarState>();
+final GlobalKey<CustomSnackBarState> yearSnackBarKey =
+    GlobalKey<CustomSnackBarState>();

--- a/lib/presentation/statistics/widgets/custom_snack_bar.dart
+++ b/lib/presentation/statistics/widgets/custom_snack_bar.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:mongbi_app/core/font.dart';
+
+class CustomSnackBar extends StatefulWidget {
+  const CustomSnackBar({super.key, this.message = '보여줄 꿈이 없다. 꿈을 알려달라몽!'});
+
+  final String message;
+
+  @override
+  State<CustomSnackBar> createState() => CustomSnackBarState();
+}
+
+class CustomSnackBarState extends State<CustomSnackBar> {
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.shrink();
+  }
+
+  void show() {
+    final snackBar = SnackBar(
+      backgroundColor: Colors.transparent,
+      elevation: 0,
+      behavior: SnackBarBehavior.floating,
+      content: speechBubbleSnackBar(),
+      duration: const Duration(hours: 12),
+      margin: EdgeInsets.symmetric(horizontal: 0, vertical: 2),
+    );
+    ScaffoldMessenger.of(context).showSnackBar(snackBar);
+  }
+
+  Widget speechBubbleSnackBar() {
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        // 아래쪽 삼각형 꼭지
+        Positioned(
+          bottom: -12,
+          left: 0,
+          right: 0,
+          child: Center(
+            child: CustomPaint(
+              size: const Size(24, 32),
+              painter: _BubblePointerPainter(color: Color(0xFF8C2EFF)),
+            ),
+          ),
+        ),
+        // 말풍선 본체
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 50),
+          child: Container(
+            width: double.infinity,
+            padding: EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+            decoration: BoxDecoration(
+              color: Color(0xFF8C2EFF), // 이미지와 유사한 진한 보라색
+              borderRadius: BorderRadius.circular(32),
+            ),
+            child: Text(
+              widget.message,
+              style: Font.title14.copyWith(fontSize: 14, color: Colors.white),
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _BubblePointerPainter extends CustomPainter {
+  _BubblePointerPainter({required this.color});
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()..color = color;
+    final path =
+        Path()
+          ..moveTo(0, 0)
+          // 가운데 아래로 곡선(뭉툭한 꼭지)
+          ..quadraticBezierTo(
+            size.width / 2,
+            size.height * 1.9, // control point (아래로 더 내려가게)
+            size.width,
+            0,
+          )
+          ..close();
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(CustomPainter oldDelegate) => false;
+}

--- a/lib/presentation/statistics/widgets/month_statistics.dart
+++ b/lib/presentation/statistics/widgets/month_statistics.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mongbi_app/core/get_responsive_ratio_by_width.dart';
 import 'package:mongbi_app/core/get_widget_info.dart';
 import 'package:mongbi_app/presentation/statistics/statistics_key/statistics_key.dart';
+import 'package:mongbi_app/presentation/statistics/widgets/custom_snack_bar.dart';
 import 'package:mongbi_app/presentation/statistics/widgets/dream_frequency_card.dart';
 import 'package:mongbi_app/presentation/statistics/widgets/dream_mood_distribution.dart';
 import 'package:mongbi_app/presentation/statistics/widgets/dream_type_mood_state.dart';
@@ -25,6 +26,7 @@ class _MonthStatisticsState extends ConsumerState<MonthStatistics> {
   bool isMonth = true;
   double? monthPickerButtonPosition;
   final ScrollController scrollController = ScrollController();
+  bool _snackBarShown = false;
 
   @override
   void initState() {
@@ -91,6 +93,17 @@ class _MonthStatisticsState extends ConsumerState<MonthStatistics> {
                     final keywordList = monthStatistics?.keywords;
                     final isFirst = frequency == 0;
 
+                    // 스낵바가 한 번만 뜨도록 제어
+                    if (isFirst && !_snackBarShown) {
+                      WidgetsBinding.instance.addPostFrameCallback((_) {
+                        monthSnackBarKey.currentState?.show();
+                        _snackBarShown = true;
+                      });
+                    } else if (!isFirst && _snackBarShown) {
+                      // 조건이 풀리면 플래그 리셋
+                      _snackBarShown = false;
+                    }
+
                     return Column(
                       children: [
                         Padding(
@@ -133,6 +146,7 @@ class _MonthStatisticsState extends ConsumerState<MonthStatistics> {
                 ),
               ],
             ),
+            CustomSnackBar(key: monthSnackBarKey),
           ],
         ),
       ],

--- a/lib/presentation/statistics/widgets/month_year_picker.dart
+++ b/lib/presentation/statistics/widgets/month_year_picker.dart
@@ -95,7 +95,9 @@ class MonthYearPickerState extends ConsumerState<MonthYearPicker> {
                                 pickerVm.onChangedMonth(
                                   DateTime(DateTime.now().year, month),
                                 );
-
+                                ScaffoldMessenger.of(
+                                  context,
+                                ).hideCurrentSnackBar();
                                 hide();
                               },
                             );
@@ -120,6 +122,9 @@ class MonthYearPickerState extends ConsumerState<MonthYearPicker> {
                                   pickerViewModelProvider.notifier,
                                 );
                                 pickerVm.onChangedYear(DateTime(year));
+                                ScaffoldMessenger.of(
+                                  context,
+                                ).hideCurrentSnackBar();
                                 hide();
                               },
                             );

--- a/lib/presentation/statistics/widgets/year_statistics.dart
+++ b/lib/presentation/statistics/widgets/year_statistics.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mongbi_app/core/get_responsive_ratio_by_width.dart';
 import 'package:mongbi_app/core/get_widget_info.dart';
 import 'package:mongbi_app/presentation/statistics/statistics_key/statistics_key.dart';
+import 'package:mongbi_app/presentation/statistics/widgets/custom_snack_bar.dart';
 import 'package:mongbi_app/presentation/statistics/widgets/dream_frequency_card.dart';
 import 'package:mongbi_app/presentation/statistics/widgets/dream_mood_distribution.dart';
 import 'package:mongbi_app/presentation/statistics/widgets/dream_type_mood_state.dart';
@@ -25,6 +26,7 @@ class _YearStatisticsState extends ConsumerState<YearStatistics> {
   bool isMonth = false;
   double? yearPickerButtonPosition;
   final ScrollController scrollController = ScrollController();
+  bool _snackBarShown = false;
 
   @override
   void initState() {
@@ -91,6 +93,17 @@ class _YearStatisticsState extends ConsumerState<YearStatistics> {
                     final keywordList = yearStatistics?.keywords;
                     final isFirst = frequency == 0;
 
+                    // 스낵바가 한 번만 뜨도록 제어
+                    if (isFirst && !_snackBarShown) {
+                      WidgetsBinding.instance.addPostFrameCallback((_) {
+                        yearSnackBarKey.currentState?.show();
+                        _snackBarShown = true;
+                      });
+                    } else if (!isFirst && _snackBarShown) {
+                      // 조건이 풀리면 플래그 리셋
+                      _snackBarShown = false;
+                    }
+
                     return Column(
                       children: [
                         Padding(
@@ -132,6 +145,7 @@ class _YearStatisticsState extends ConsumerState<YearStatistics> {
                 ),
               ],
             ),
+            CustomSnackBar(key: yearSnackBarKey),
           ],
         ),
       ],


### PR DESCRIPTION
### 🚀 개요
해당 월별/년도별 통계 자료가 없을 경우 꿈 작성 페이지로 유도하는 스낵바 표시

### 🔧 작업 내용
- 바텀 네비게이션바 터치 시 스낵바 제거
- 월별/년도별 탭바 이동 시 스택바 제거

### 📸 실행 화면
<img src="https://github.com/user-attachments/assets/366b5bda-0000-42a1-8f2b-9a96c73edb10" width="300" height="600"/>

### 💡 Issue
Closes #91 
