### PR TITLE
탭바 이동 후 다른 페이지에서 돌아올 때 탭바 인덱스 유지하기

### DIFF
--- a/lib/presentation/statistics/models/statistics_model.dart
+++ b/lib/presentation/statistics/models/statistics_model.dart
@@ -1,12 +1,21 @@
 import 'package:mongbi_app/domain/entities/statistics.dart';
 
 class StatisticsModel {
-  StatisticsModel({this.month, this.year});
+  StatisticsModel({this.month, this.year, this.tabBarIndex});
 
   Statistics? month;
   Statistics? year;
+  int? tabBarIndex;
 
-  StatisticsModel copyWith({Statistics? month, Statistics? year}) {
-    return StatisticsModel(month: month ?? this.month, year: year ?? this.year);
+  StatisticsModel copyWith({
+    Statistics? month,
+    Statistics? year,
+    int? tabBarIndex,
+  }) {
+    return StatisticsModel(
+      month: month ?? this.month,
+      year: year ?? this.year,
+      tabBarIndex: tabBarIndex ?? this.tabBarIndex,
+    );
   }
 }

--- a/lib/presentation/statistics/statistics_page.dart
+++ b/lib/presentation/statistics/statistics_page.dart
@@ -1,19 +1,40 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mongbi_app/core/font.dart';
 import 'package:mongbi_app/core/get_responsive_ratio_by_width.dart';
 import 'package:mongbi_app/presentation/statistics/widgets/month_statistics.dart';
 import 'package:mongbi_app/presentation/statistics/widgets/tab_bar_title.dart';
 import 'package:mongbi_app/presentation/statistics/widgets/year_statistics.dart';
+import 'package:mongbi_app/providers/statistics_provider.dart';
 
-class StatisticsPage extends StatefulWidget {
+class StatisticsPage extends ConsumerStatefulWidget {
   const StatisticsPage({super.key});
 
   @override
-  State<StatisticsPage> createState() => _StatisticsPageState();
+  ConsumerState<StatisticsPage> createState() => _StatisticsPageState();
 }
 
-class _StatisticsPageState extends State<StatisticsPage> {
+class _StatisticsPageState extends ConsumerState<StatisticsPage>
+    with TickerProviderStateMixin {
   final double horizontalPadding = 24;
+  late TabController tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    tabController = TabController(
+      length: 2,
+      vsync: this,
+      initialIndex:
+          ref.read(statisticsViewModelProvider).value?.tabBarIndex ?? 0,
+    );
+  }
+
+  @override
+  void dispose() {
+    tabController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -34,39 +55,40 @@ class _StatisticsPageState extends State<StatisticsPage> {
           ),
         ),
         SafeArea(
-          child: DefaultTabController(
-            length: 2,
-            child: NestedScrollView(
-              headerSliverBuilder: (context, innerBoxIsScrolled) {
-                return [
-                  // 상단 제목 필요 시 사용
-                  SliverToBoxAdapter(
-                    child: Padding(
-                      padding: EdgeInsets.symmetric(
-                        horizontal: horizontalPadding,
-                        vertical: 16,
-                      ),
-                      child: Text('모몽의 꿈 통계', style: Font.title20),
+          child: NestedScrollView(
+            headerSliverBuilder: (context, innerBoxIsScrolled) {
+              return [
+                // 상단 제목 필요 시 사용
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: EdgeInsets.symmetric(
+                      horizontal: horizontalPadding,
+                      vertical: 16,
                     ),
+                    child: Text('모몽의 꿈 통계', style: Font.title20),
                   ),
+                ),
 
-                  // 커스텀 탭바 고정
-                  SliverPersistentHeader(
-                    pinned: true,
-                    delegate: _SliverTabBarDelegate(
-                      TabBarTitle(horizontalPadding: horizontalPadding),
-                      tabBarHeight,
+                // 커스텀 탭바 고정
+                SliverPersistentHeader(
+                  pinned: true,
+                  delegate: _SliverTabBarDelegate(
+                    TabBarTitle(
+                      tabController: tabController,
+                      horizontalPadding: horizontalPadding,
                     ),
+                    tabBarHeight,
                   ),
-                ];
-              },
-              body: TabBarView(
-                physics: NeverScrollableScrollPhysics(),
-                children: [
-                  MonthStatistics(horizontalPadding: horizontalPadding),
-                  YearStatistics(horizontalPadding: horizontalPadding),
-                ],
-              ),
+                ),
+              ];
+            },
+            body: TabBarView(
+              controller: tabController,
+              physics: NeverScrollableScrollPhysics(),
+              children: [
+                MonthStatistics(horizontalPadding: horizontalPadding),
+                YearStatistics(horizontalPadding: horizontalPadding),
+              ],
             ),
           ),
         ),

--- a/lib/presentation/statistics/view_models/statistics_view_model.dart
+++ b/lib/presentation/statistics/view_models/statistics_view_model.dart
@@ -70,4 +70,12 @@ class StatisticsViewModel extends AsyncNotifier<StatisticsModel?> {
       state = AsyncValue.error(e, s);
     }
   }
+
+  void onChangetabBarIndex(int index) {
+    final currentState = state.value ?? StatisticsModel();
+    final newState = currentState.copyWith(tabBarIndex: index);
+
+    // 상태 업데이트
+    state = AsyncValue.data(newState);
+  }
 }

--- a/lib/presentation/statistics/widgets/tab_bar_title.dart
+++ b/lib/presentation/statistics/widgets/tab_bar_title.dart
@@ -5,8 +5,14 @@ import 'package:mongbi_app/core/get_responsive_ratio_by_width.dart';
 import 'package:mongbi_app/providers/statistics_provider.dart';
 
 class TabBarTitle extends StatelessWidget {
-  const TabBarTitle({super.key, required this.horizontalPadding});
+  const TabBarTitle({
+    super.key,
 
+    required this.tabController,
+    required this.horizontalPadding,
+  });
+
+  final TabController tabController;
   final double horizontalPadding;
 
   @override
@@ -28,8 +34,10 @@ class TabBarTitle extends StatelessWidget {
             final statisticsVm = ref.read(statisticsViewModelProvider.notifier);
 
             return TabBar(
+              controller: tabController,
               onTap: (value) {
                 ScaffoldMessenger.of(context).hideCurrentSnackBar();
+                statisticsVm.onChangetabBarIndex(value);
                 if (value == 0) {
                   statisticsVm.fetchMonthStatistics();
                 } else {


### PR DESCRIPTION
### 🚀 개요
탭바 이동 후 다른 페이지에서 돌아올 때 탭바 인덱스 유지하기 #111

### 🔧 작업 내용
- DefaultTabController 대신 TabController 사용

### 💡 Issue
Closes  #111 
