### PR TITLE
[Dream] 꿈 기분 선택 점수 오류 수정

### DIFF
--- a/lib/presentation/dream/view_models/dream_write_view_model.dart
+++ b/lib/presentation/dream/view_models/dream_write_view_model.dart
@@ -31,7 +31,7 @@ class DreamWriteViewModel extends Notifier<DreamWriteState> {
 
     final dream = await ref
         .read(analyzeAndSaveDreamUseCaseProvider)
-        .execute(uid, state.dreamContent, state.selectedIndex);
+        .execute(uid, state.dreamContent, state.selectedIndex + 1);
     ref.read(dreamInterpretationViewModelProvider.notifier).setDream(dream);
   }
 }


### PR DESCRIPTION
### 🚀 개요
- 꿈 선택시 1점부터 5점까지이지만, 현재 코드에서 0점부터 4점까지로 설정되어 있음

### 🔧 작업 내용
- 꿈을 작성할 때 선택한 기분 인덱스에 1을 더해서 저장

### 💡 Issue
Closes #123 
