### PR TITLE
[Dream] 꿈 재작성할 때 꿈 기분 리셋

### DIFF
--- a/lib/presentation/dream/view_models/dream_write_view_model.dart
+++ b/lib/presentation/dream/view_models/dream_write_view_model.dart
@@ -3,7 +3,7 @@ import 'package:mongbi_app/presentation/dream/models/dream_write_state.dart';
 import 'package:mongbi_app/providers/core_providers.dart';
 import 'package:mongbi_app/providers/dream_provider.dart';
 
-class DreamWriteViewModel extends Notifier<DreamWriteState> {
+class DreamWriteViewModel extends AutoDisposeNotifier<DreamWriteState> {
   @override
   DreamWriteState build() {
     return DreamWriteState();

--- a/lib/providers/dream_provider.dart
+++ b/lib/providers/dream_provider.dart
@@ -50,7 +50,7 @@ final analyzeAndSaveDreamUseCaseProvider = Provider<AnalyzeAndSaveDreamUseCase>(
 );
 
 final dreamWriteViewModelProvider =
-    NotifierProvider<DreamWriteViewModel, DreamWriteState>(
+    AutoDisposeNotifierProvider<DreamWriteViewModel, DreamWriteState>(
       () => DreamWriteViewModel(),
     );
 


### PR DESCRIPTION
### 🚀 개요
- 꿈을 두 번째로 작성하면 이전에 선택한 꿈 기분이 선택되어 있는데 이를 리셋하도록 수정

### 🔧 작업 내용
- DreamWriteViewModel과 Provider를 AutoDisposeNotifier로 수정

### 💡 Issue
Closes #147 
