### PR TITLE
[Challenge] 배포 전에는 챌린지 사용 X

### DIFF
--- a/lib/presentation/dream/dream_interpretation_page.dart
+++ b/lib/presentation/dream/dream_interpretation_page.dart
@@ -51,7 +51,7 @@ class _DreamInterpretationPageState
                 SizedBox(height: 24),
                 CustomButton(
                   text: '오 맞아!',
-                  onSubmit: () => context.pushReplacement('/challenge_intro'),
+                  onSubmit: () => context.pushReplacement('/home'),
                 ),
                 SizedBox(height: 24),
               ],


### PR DESCRIPTION
### 🚀 개요
- 배포 전에는 챌린지 사용하지 않도록 UI 수정

### 🔧 작업 내용
- 꿈 해석 화면에서 하단 버튼을 클릭하면 챌린지 인트로 화면에서 홈 화면으로 이동하도록 수정

### 💡 Issue
Closes #150 
