### PR TITLE
[Dream] 꿈을 하루에 두 번만 작성할 수 있게 로직 변경

### DIFF
--- a/lib/data/data_sources/dream_check_data_source.dart
+++ b/lib/data/data_sources/dream_check_data_source.dart
@@ -1,0 +1,3 @@
+abstract interface class DreamCheckDataSource {
+  Future<bool> canWriteDreamToday({required int uid});
+}

--- a/lib/data/data_sources/remote_dream_check_data_source.dart
+++ b/lib/data/data_sources/remote_dream_check_data_source.dart
@@ -1,0 +1,45 @@
+import 'package:dio/dio.dart';
+import 'package:mongbi_app/data/data_sources/dream_check_data_source.dart';
+
+class RemoteDreamCheckDataSource implements DreamCheckDataSource {
+  RemoteDreamCheckDataSource({required this.dio});
+
+  final Dio dio;
+
+  @override
+  Future<bool> canWriteDreamToday({required int uid}) async {
+    try {
+      final response = await dio.get('/dreams/$uid');
+
+      if ((response.statusCode == 200 || response.statusCode == 201) &&
+          response.data['success'] == true) {
+        final List<dynamic> dreamList = response.data['data'];
+
+        if (dreamList.isEmpty) {
+          return true;
+        }
+
+        final latestDream = dreamList[0];
+        final dreamRegDate = DateTime.parse(latestDream['DREAM_REG_DATE']);
+
+        final today = DateTime.now();
+        final todayDate = DateTime(today.year, today.month, today.day);
+        final dreamDate = DateTime(
+          dreamRegDate.year,
+          dreamRegDate.month,
+          dreamRegDate.day,
+        );
+        final isToday = todayDate.isAtSameMomentAs(dreamDate);
+
+        return !isToday;
+      } else {
+        throw Exception(response.data['message'] ?? '꿈 작성 가능 여부 확인에 실패했습니다.');
+      }
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 404) {
+        return true;
+      }
+      throw Exception(e.message ?? '네트워크 오류가 발생했습니다.');
+    }
+  }
+}

--- a/lib/data/repositories/remote_dream_repository.dart
+++ b/lib/data/repositories/remote_dream_repository.dart
@@ -1,14 +1,20 @@
 import 'package:mongbi_app/data/data_sources/dream_analysis_data_source.dart';
+import 'package:mongbi_app/data/data_sources/dream_check_data_source.dart';
 import 'package:mongbi_app/data/data_sources/dream_save_data_source.dart';
 import 'package:mongbi_app/data/dtos/dream_dto.dart';
 import 'package:mongbi_app/domain/entities/dream.dart';
 import 'package:mongbi_app/domain/repositories/dream_repository.dart';
 
 class RemoteDreamRepository implements DreamRepository {
-  RemoteDreamRepository(this.dreamSaveDataSource, this.dreamAnalysisDataSource);
+  RemoteDreamRepository(
+    this.dreamSaveDataSource,
+    this.dreamAnalysisDataSource,
+    this.dreamCheckDataSource,
+  );
 
   final DreamSaveDataSource dreamSaveDataSource;
   final DreamAnalysisDataSource dreamAnalysisDataSource;
+  final DreamCheckDataSource dreamCheckDataSource;
 
   @override
   Future<int> saveDream(Dream dream) async {
@@ -17,7 +23,11 @@ class RemoteDreamRepository implements DreamRepository {
   }
 
   @override
-  Future<Dream> analyzeDream(int uid, String dreamContent, int dreamScore) async {
+  Future<Dream> analyzeDream(
+    int uid,
+    String dreamContent,
+    int dreamScore,
+  ) async {
     final responseMap = await dreamAnalysisDataSource.analyzeDream(
       dreamContent,
       dreamScore,
@@ -47,5 +57,10 @@ class RemoteDreamRepository implements DreamRepository {
       dreamCategory: responseMap['dreamCategory'] as String,
     );
     return dream;
+  }
+
+  @override
+  Future<bool> canWriteDreamToday(int uid) async {
+    return await dreamCheckDataSource.canWriteDreamToday(uid: uid);
   }
 }

--- a/lib/domain/repositories/dream_repository.dart
+++ b/lib/domain/repositories/dream_repository.dart
@@ -4,4 +4,6 @@ abstract interface class DreamRepository {
   Future<int> saveDream(Dream dream);
 
   Future<Dream> analyzeDream(int uid, String dreamContent, int dreamScore);
+
+  Future<bool> canWriteDreamToday(int uid);
 }

--- a/lib/domain/use_cases/can_write_dream_today_use_case.dart
+++ b/lib/domain/use_cases/can_write_dream_today_use_case.dart
@@ -1,0 +1,11 @@
+import 'package:mongbi_app/domain/repositories/dream_repository.dart';
+
+class CanWriteDreamTodayUseCase {
+  CanWriteDreamTodayUseCase({required this.repository});
+
+  final DreamRepository repository;
+
+  Future<bool> execute(int uid) async {
+    return await repository.canWriteDreamToday(uid);
+  }
+}

--- a/lib/presentation/challenge/challenge_page.dart
+++ b/lib/presentation/challenge/challenge_page.dart
@@ -154,7 +154,7 @@ class ChallengePage extends ConsumerWidget {
                     );
                     ScaffoldMessenger.of(
                       context,
-                    ).showSnackBar(customSnackBar('선물을 먼저 골라줘'));
+                    ).showSnackBar(customSnackBar('선물을 먼저 골라줘', 80));
                     return;
                   }
 

--- a/lib/presentation/challenge/challenge_page.dart
+++ b/lib/presentation/challenge/challenge_page.dart
@@ -148,7 +148,7 @@ class ChallengePage extends ConsumerWidget {
                 },
                 onRightPressed: () async {
                   if (selectedIndex == null) {
-                    FirebaseAnalytics.instance.logEvent(
+                    await FirebaseAnalytics.instance.logEvent(
                       name: 'challenge_not_selected',
                       parameters: {'screen': 'ChallengePage'},
                     );

--- a/lib/presentation/common/custom_snack_bar.dart
+++ b/lib/presentation/common/custom_snack_bar.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:mongbi_app/core/font.dart';
 
-SnackBar customSnackBar(String message) {
+SnackBar customSnackBar(String message, double margin) {
   return SnackBar(
     backgroundColor: Colors.transparent,
     elevation: 0,
     behavior: SnackBarBehavior.floating,
-    margin: EdgeInsets.only(bottom: 80),
+    margin: EdgeInsets.only(bottom: margin),
     duration: Duration(seconds: 2),
     content: Row(
       mainAxisSize: MainAxisSize.min,

--- a/lib/providers/dream_provider.dart
+++ b/lib/providers/dream_provider.dart
@@ -4,6 +4,7 @@ import 'package:mongbi_app/data/data_sources/dream_analysis_data_source.dart';
 import 'package:mongbi_app/data/data_sources/dream_check_data_source.dart';
 import 'package:mongbi_app/data/data_sources/dream_save_data_source.dart';
 import 'package:mongbi_app/data/data_sources/remote_dream_analysis_data_source.dart';
+import 'package:mongbi_app/data/data_sources/remote_dream_check_data_source.dart';
 import 'package:mongbi_app/data/data_sources/remote_dream_data_source.dart';
 import 'package:mongbi_app/data/repositories/remote_dream_repository.dart';
 import 'package:mongbi_app/domain/repositories/dream_repository.dart';
@@ -36,6 +37,7 @@ final _dreamRepositoryProvider = Provider<DreamRepository>(
   (ref) => RemoteDreamRepository(
     ref.read(_dreamDataSourceProvider),
     ref.read(_dreamAnalysisDataSource),
+    ref.read(_dreamCheckDataSource),
   ),
 );
 

--- a/lib/providers/dream_provider.dart
+++ b/lib/providers/dream_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mongbi_app/data/data_sources/dream_analysis_data_source.dart';
+import 'package:mongbi_app/data/data_sources/dream_check_data_source.dart';
 import 'package:mongbi_app/data/data_sources/dream_save_data_source.dart';
 import 'package:mongbi_app/data/data_sources/remote_dream_analysis_data_source.dart';
 import 'package:mongbi_app/data/data_sources/remote_dream_data_source.dart';
@@ -25,6 +26,10 @@ final _dreamAnalysisDataSource = Provider<DreamAnalysisDataSource>(
     apiKey: dotenv.env['CLAUDE_API_KEY']!,
     baseUrl: dotenv.env['CLAUDE_URL']!,
   ),
+);
+
+final _dreamCheckDataSource = Provider<DreamCheckDataSource>(
+  (ref) => RemoteDreamCheckDataSource(dio: ref.read(dioProvider)),
 );
 
 final _dreamRepositoryProvider = Provider<DreamRepository>(

--- a/lib/providers/dream_provider.dart
+++ b/lib/providers/dream_provider.dart
@@ -10,6 +10,7 @@ import 'package:mongbi_app/data/repositories/remote_dream_repository.dart';
 import 'package:mongbi_app/domain/repositories/dream_repository.dart';
 import 'package:mongbi_app/domain/use_cases/analyze_and_save_dream_use_case.dart';
 import 'package:mongbi_app/domain/use_cases/analyze_dream_use_case.dart';
+import 'package:mongbi_app/domain/use_cases/can_write_dream_today_use_case.dart';
 import 'package:mongbi_app/domain/use_cases/save_dream_use_case.dart';
 import 'package:mongbi_app/presentation/dream/models/dream_interpretation_state.dart';
 import 'package:mongbi_app/presentation/dream/models/dream_write_state.dart';
@@ -54,6 +55,11 @@ final analyzeAndSaveDreamUseCaseProvider = Provider<AnalyzeAndSaveDreamUseCase>(
     ref.read(_analyzeDreamUseCaseProvider),
     ref.read(_saveDreamUseCaseProvider),
   ),
+);
+
+final canWriteDreamTodayUseCaseProvider = Provider<CanWriteDreamTodayUseCase>(
+  (ref) =>
+      CanWriteDreamTodayUseCase(repository: ref.read(_dreamRepositoryProvider)),
 );
 
 final dreamWriteViewModelProvider =


### PR DESCRIPTION
### 🚀 개요
- 서버에 하루 꿈을 작성한 횟수를 저장
- 꿈 작성하기 전에 꿈 횟수를 불러오고, 만약 2이상이라면 SnackBar 알림

### 🔧 작업 내용
- uid로 사용자가 꿈 목록을 가져오고, 최근 꿈 작성 날짜가 오늘과 같을 때 작성할 수 없도록 스낵바 표시

### 💡 Issue
Closes #60 
