### PR TITLE
[Dream] QA 피드백 적용 - UI 변경

### DIFF
--- a/lib/presentation/dream/dream_interpretation_page.dart
+++ b/lib/presentation/dream/dream_interpretation_page.dart
@@ -22,8 +22,11 @@ class _DreamInterpretationPageState
     final dream = ref.watch(dreamInterpretationViewModelProvider);
 
     return Scaffold(
-      appBar: AppBar(),
-      backgroundColor: Color(0xfffcf6ff),
+      appBar: AppBar(
+        title: Text('오늘 꿈은 말이야...', style: Font.title20),
+        titleSpacing: 24,
+      ),
+      backgroundColor: Color(0xFFFCF6FF),
       body: SingleChildScrollView(
         child: SafeArea(
           child: Padding(
@@ -40,7 +43,7 @@ class _DreamInterpretationPageState
                 ),
                 SizedBox(height: 24),
                 DreamSectionCard(
-                  title: '심리 상태는',
+                  title: '따라서 너의 심리는',
                   subTitle: dream.psychologicalSubTitle,
                   content: dream.psychologicalStateInterpretation,
                   keywords: dream.psychologicalStateKeywords,

--- a/lib/presentation/dream/dream_interpretation_page.dart
+++ b/lib/presentation/dream/dream_interpretation_page.dart
@@ -29,7 +29,9 @@ class _DreamInterpretationPageState
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 24),
             child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
+                SizedBox(height: 16),
                 DreamSectionCard(
                   title: '꿈을 해석 해보자면',
                   subTitle: dream.dreamSubTitle,

--- a/lib/presentation/dream/dream_interpretation_page.dart
+++ b/lib/presentation/dream/dream_interpretation_page.dart
@@ -41,19 +41,19 @@ class _DreamInterpretationPageState
                   content: dream.dreamInterpretation,
                   keywords: dream.dreamKeywords,
                 ),
-                SizedBox(height: 24),
+                SizedBox(height: 32),
                 DreamSectionCard(
                   title: '따라서 너의 심리는',
                   subTitle: dream.psychologicalSubTitle,
                   content: dream.psychologicalStateInterpretation,
                   keywords: dream.psychologicalStateKeywords,
                 ),
-                SizedBox(height: 24),
+                SizedBox(height: 32),
                 MongbiCommentCard(
                   title: '몽비의 한마디',
                   comment: dream.mongbiComment,
                 ),
-                SizedBox(height: 24),
+                SizedBox(height: 40),
                 CustomButton(
                   text: '오 맞아!',
                   onSubmit: () => context.pushReplacement('/challenge_intro'),

--- a/lib/presentation/dream/widgets/dream_section_card.dart
+++ b/lib/presentation/dream/widgets/dream_section_card.dart
@@ -35,7 +35,7 @@ class DreamSectionCard extends StatelessWidget {
               SizedBox(height: 16),
               Text(
                 content,
-                style: Font.body14.copyWith(color: Colors.grey[900]),
+                style: Font.body14.copyWith(color: Color(0xFFF5F4F5)),
               ),
               SizedBox(height: 16),
               SizedBox(
@@ -53,7 +53,7 @@ class DreamSectionCard extends StatelessWidget {
                         ),
                         child: Text(
                           '#${keywords[index]}',
-                          style: Font.body12.copyWith(color: Colors.grey[600]),
+                          style: Font.body12.copyWith(color: Color(0xFF57525B)),
                         ),
                       ),
                 ),

--- a/lib/presentation/dream/widgets/dream_section_card.dart
+++ b/lib/presentation/dream/widgets/dream_section_card.dart
@@ -35,7 +35,7 @@ class DreamSectionCard extends StatelessWidget {
               SizedBox(height: 16),
               Text(
                 content,
-                style: Font.body14.copyWith(color: Color(0xFFF5F4F5)),
+                style: Font.body14.copyWith(color: Color(0xFF1A181B)),
               ),
               SizedBox(height: 16),
               SizedBox(
@@ -46,9 +46,13 @@ class DreamSectionCard extends StatelessWidget {
                   separatorBuilder: (context, index) => SizedBox(width: 8),
                   itemBuilder:
                       (context, index) => Container(
-                        padding: EdgeInsets.all(8),
+                        alignment: Alignment.center,
+                        padding: const EdgeInsets.symmetric(
+                          vertical: 4,
+                          horizontal: 8,
+                        ),
                         decoration: BoxDecoration(
-                          color: Colors.grey[100],
+                          color: Color(0xF5F5F4F5),
                           borderRadius: BorderRadius.circular(999),
                         ),
                         child: Text(


### PR DESCRIPTION
### 🚀 개요
- 꿈 해석 화면 앱바 타이틀 추가
- 심리 상태 타이틀 수정
- 아이템 간 상하좌우 패딩 조절
- 배경 색상 수정

### 🔧 작업 내용
- 꿈 해석 화면 앱바 타이틀 추가
- 심리 상태 타이틀 수정
- 아이템 간 상하좌우 패딩 조절
- 배경 색상 수정

### 💡 Issue
Closes #180 
