### PR TITLE
[Dream] 꿈 해석 후, 다시 작성

### DIFF
--- a/lib/core/router.dart
+++ b/lib/core/router.dart
@@ -102,7 +102,11 @@ final GoRouter router = GoRouter(
       pageBuilder:
           (context, state) => buildFadeTransitionPage(
             key: state.pageKey,
-            child: DreamWritePage(),
+            child: DreamWritePage(
+              isFirst:
+                  bool.tryParse('${state.uri.queryParameters['isFirst']}') ??
+                  true,
+            ),
           ),
     ),
     GoRoute(
@@ -110,7 +114,11 @@ final GoRouter router = GoRouter(
       pageBuilder:
           (context, state) => buildFadeTransitionPage(
             key: state.pageKey,
-            child: DreamAnalysisLoadingPage(),
+            child: DreamAnalysisLoadingPage(
+              isFirst:
+                  bool.tryParse('${state.uri.queryParameters['isFirst']}') ??
+                  true,
+            ),
           ),
     ),
     GoRoute(
@@ -118,12 +126,21 @@ final GoRouter router = GoRouter(
       pageBuilder:
           (context, state) => buildFadeTransitionPage(
             key: state.pageKey,
-            child: DreamAnalysisResultPage(),
+            child: DreamAnalysisResultPage(
+              isFirst:
+                  bool.tryParse('${state.uri.queryParameters['isFirst']}') ??
+                  true,
+            ),
           ),
     ),
     GoRoute(
       path: '/dream_interpretation',
-      builder: (context, state) => DreamInterpretationPage(),
+      builder:
+          (context, state) => DreamInterpretationPage(
+            isFirst:
+                bool.tryParse('${state.uri.queryParameters['isFirst']}') ??
+                true,
+          ),
     ),
     GoRoute(
       path: '/challenge_intro',

--- a/lib/presentation/dream/dream_analysis_loading_page.dart
+++ b/lib/presentation/dream/dream_analysis_loading_page.dart
@@ -6,7 +6,9 @@ import 'package:mongbi_app/presentation/common/floating_animation_widget.dart';
 import 'package:mongbi_app/providers/dream_provider.dart';
 
 class DreamAnalysisLoadingPage extends ConsumerStatefulWidget {
-  const DreamAnalysisLoadingPage({super.key});
+  const DreamAnalysisLoadingPage({super.key, required this.isFirst});
+
+  final bool isFirst;
 
   @override
   ConsumerState<DreamAnalysisLoadingPage> createState() =>
@@ -70,7 +72,9 @@ class _DreamAnalysisLoadingPageState
     try {
       await ref.read(dreamWriteViewModelProvider.notifier).submitDream();
       if (mounted) {
-        context.pushReplacement('/dream_analysis_result');
+        context.pushReplacement(
+          '/dream_analysis_result?isFirst=${widget.isFirst}',
+        );
       }
     } catch (e) {
       if (mounted) {

--- a/lib/presentation/dream/dream_analysis_result_page.dart
+++ b/lib/presentation/dream/dream_analysis_result_page.dart
@@ -4,7 +4,9 @@ import 'package:mongbi_app/core/font.dart';
 import 'package:mongbi_app/presentation/common/floating_animation_widget.dart';
 
 class DreamAnalysisResultPage extends StatefulWidget {
-  const DreamAnalysisResultPage({super.key});
+  const DreamAnalysisResultPage({super.key, required this.isFirst});
+
+  final bool isFirst;
 
   @override
   State<DreamAnalysisResultPage> createState() =>
@@ -18,7 +20,9 @@ class _DreamAnalysisResultPageState extends State<DreamAnalysisResultPage> {
 
     Future.delayed(const Duration(seconds: 1), () {
       if (mounted) {
-        context.pushReplacement('/dream_interpretation');
+        context.pushReplacement(
+          '/dream_interpretation?isFirst=${widget.isFirst}',
+        );
       }
     });
   }

--- a/lib/presentation/dream/dream_interpretation_page.dart
+++ b/lib/presentation/dream/dream_interpretation_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mongbi_app/core/font.dart';
+import 'package:mongbi_app/presentation/common/action_button_row.dart';
 import 'package:mongbi_app/presentation/dream/widgets/custom_button.dart';
 import 'package:mongbi_app/presentation/dream/widgets/dream_section_card.dart';
 import 'package:mongbi_app/presentation/dream/widgets/mongbi_comment_card.dart';
@@ -56,10 +57,27 @@ class _DreamInterpretationPageState
                   comment: dream.mongbiComment,
                 ),
                 SizedBox(height: 40),
-                CustomButton(
-                  text: '오 맞아!',
-                  onSubmit: () => context.pushReplacement('/challenge_intro'),
-                ),
+
+                if (dream.interpretationCount == 1) ...[
+                  ActionButtonRow(
+                    leftText: '음... 아닌데?',
+                    rightText: '오 맞아!',
+                    onLeftPressed: () {
+                      ref
+                          .read(dreamInterpretationViewModelProvider.notifier)
+                          .incrementInterpretationCount();
+                      context.pushReplacement('/dream_write');
+                    },
+                    onRightPressed:
+                        () => context.pushReplacement('/challenge_intro'),
+                  ),
+                ] else ...[
+                  CustomButton(
+                    text: '고마워',
+                    onSubmit: () => context.pushReplacement('/challenge_intro'),
+                  ),
+                ],
+
                 SizedBox(height: 24),
               ],
             ),

--- a/lib/presentation/dream/dream_interpretation_page.dart
+++ b/lib/presentation/dream/dream_interpretation_page.dart
@@ -9,7 +9,9 @@ import 'package:mongbi_app/presentation/dream/widgets/mongbi_comment_card.dart';
 import 'package:mongbi_app/providers/dream_provider.dart';
 
 class DreamInterpretationPage extends ConsumerStatefulWidget {
-  const DreamInterpretationPage({super.key});
+  const DreamInterpretationPage({super.key, required this.isFirst});
+
+  final bool isFirst;
 
   @override
   ConsumerState<DreamInterpretationPage> createState() =>
@@ -58,15 +60,12 @@ class _DreamInterpretationPageState
                 ),
                 SizedBox(height: 40),
 
-                if (dream.interpretationCount == 1) ...[
+                if (widget.isFirst) ...[
                   ActionButtonRow(
                     leftText: '음... 아닌데?',
                     rightText: '오 맞아!',
                     onLeftPressed: () {
-                      ref
-                          .read(dreamInterpretationViewModelProvider.notifier)
-                          .incrementInterpretationCount();
-                      context.pushReplacement('/dream_write');
+                      context.pushReplacement('/dream_write?isFirst=false');
                     },
                     onRightPressed:
                         () => context.pushReplacement('/challenge_intro'),

--- a/lib/presentation/dream/dream_write_page.dart
+++ b/lib/presentation/dream/dream_write_page.dart
@@ -9,7 +9,9 @@ import 'package:mongbi_app/presentation/dream/widgets/mood_selection_row.dart';
 import 'package:mongbi_app/providers/dream_provider.dart';
 
 class DreamWritePage extends ConsumerStatefulWidget {
-  const DreamWritePage({super.key});
+  const DreamWritePage({super.key, required this.isFirst});
+
+  final bool isFirst;
 
   @override
   ConsumerState<DreamWritePage> createState() => _DreamWritePageState();
@@ -95,7 +97,7 @@ class _DreamWritePageState extends ConsumerState<DreamWritePage> {
                             isButtonEnabled
                                 ? () {
                                   context.pushReplacement(
-                                    '/dream_analysis_loading',
+                                    '/dream_analysis_loading?isFirst=${widget.isFirst}',
                                   );
                                 }
                                 : null,

--- a/lib/presentation/dream/models/dream_interpretation_state.dart
+++ b/lib/presentation/dream/models/dream_interpretation_state.dart
@@ -9,6 +9,7 @@ class DreamInterpretationState {
     this.psychologicalStateKeywords = const [],
     this.mongbiComment = '',
     this.dreamCategory = '',
+    this.interpretationCount = 1,
   });
 
   final int dreamId;
@@ -20,4 +21,5 @@ class DreamInterpretationState {
   final List<String> psychologicalStateKeywords;
   final String mongbiComment;
   final String dreamCategory;
+  final int interpretationCount;
 }

--- a/lib/presentation/dream/models/dream_interpretation_state.dart
+++ b/lib/presentation/dream/models/dream_interpretation_state.dart
@@ -22,4 +22,34 @@ class DreamInterpretationState {
   final String mongbiComment;
   final String dreamCategory;
   final int interpretationCount;
+
+  DreamInterpretationState copyWith({
+    int? dreamId,
+    String? dreamSubTitle,
+    String? dreamInterpretation,
+    List<String>? dreamKeywords,
+    String? psychologicalSubTitle,
+    String? psychologicalStateInterpretation,
+    List<String>? psychologicalStateKeywords,
+    String? mongbiComment,
+    String? dreamCategory,
+    int? interpretationCount,
+  }) {
+    return DreamInterpretationState(
+      dreamId: dreamId ?? this.dreamId,
+      dreamSubTitle: dreamSubTitle ?? this.dreamSubTitle,
+      dreamInterpretation: dreamInterpretation ?? this.dreamInterpretation,
+      dreamKeywords: dreamKeywords ?? this.dreamKeywords,
+      psychologicalSubTitle:
+          psychologicalSubTitle ?? this.psychologicalSubTitle,
+      psychologicalStateInterpretation:
+          psychologicalStateInterpretation ??
+          this.psychologicalStateInterpretation,
+      psychologicalStateKeywords:
+          psychologicalStateKeywords ?? this.psychologicalStateKeywords,
+      mongbiComment: mongbiComment ?? this.mongbiComment,
+      dreamCategory: dreamCategory ?? this.dreamCategory,
+      interpretationCount: interpretationCount ?? this.interpretationCount,
+    );
+  }
 }

--- a/lib/presentation/dream/models/dream_interpretation_state.dart
+++ b/lib/presentation/dream/models/dream_interpretation_state.dart
@@ -9,7 +9,6 @@ class DreamInterpretationState {
     this.psychologicalStateKeywords = const [],
     this.mongbiComment = '',
     this.dreamCategory = '',
-    this.interpretationCount = 1,
   });
 
   final int dreamId;
@@ -21,7 +20,6 @@ class DreamInterpretationState {
   final List<String> psychologicalStateKeywords;
   final String mongbiComment;
   final String dreamCategory;
-  final int interpretationCount;
 
   DreamInterpretationState copyWith({
     int? dreamId,
@@ -33,7 +31,6 @@ class DreamInterpretationState {
     List<String>? psychologicalStateKeywords,
     String? mongbiComment,
     String? dreamCategory,
-    int? interpretationCount,
   }) {
     return DreamInterpretationState(
       dreamId: dreamId ?? this.dreamId,
@@ -49,7 +46,6 @@ class DreamInterpretationState {
           psychologicalStateKeywords ?? this.psychologicalStateKeywords,
       mongbiComment: mongbiComment ?? this.mongbiComment,
       dreamCategory: dreamCategory ?? this.dreamCategory,
-      interpretationCount: interpretationCount ?? this.interpretationCount,
     );
   }
 }

--- a/lib/presentation/dream/view_models/dream_interpretation_view_model.dart
+++ b/lib/presentation/dream/view_models/dream_interpretation_view_model.dart
@@ -18,6 +18,15 @@ class DreamInterpretationViewModel extends Notifier<DreamInterpretationState> {
       psychologicalStateInterpretation: dream.psychologicalStateInterpretation,
       psychologicalStateKeywords: dream.psychologicalStateKeywords,
       mongbiComment: dream.mongbiComment,
+      interpretationCount: state.interpretationCount,
     );
+  }
+
+  void incrementInterpretationCount() {
+    state = state.copyWith(interpretationCount: state.interpretationCount + 1);
+  }
+
+  void resetInterpretationCount() {
+    state = state.copyWith(interpretationCount: 1);
   }
 }

--- a/lib/presentation/dream/view_models/dream_interpretation_view_model.dart
+++ b/lib/presentation/dream/view_models/dream_interpretation_view_model.dart
@@ -18,15 +18,6 @@ class DreamInterpretationViewModel extends Notifier<DreamInterpretationState> {
       psychologicalStateInterpretation: dream.psychologicalStateInterpretation,
       psychologicalStateKeywords: dream.psychologicalStateKeywords,
       mongbiComment: dream.mongbiComment,
-      interpretationCount: state.interpretationCount,
     );
-  }
-
-  void incrementInterpretationCount() {
-    state = state.copyWith(interpretationCount: state.interpretationCount + 1);
-  }
-
-  void resetInterpretationCount() {
-    state = state.copyWith(interpretationCount: 1);
   }
 }

--- a/lib/presentation/dream/view_models/dream_write_view_model.dart
+++ b/lib/presentation/dream/view_models/dream_write_view_model.dart
@@ -34,13 +34,6 @@ class DreamWriteViewModel extends AutoDisposeNotifier<DreamWriteState> {
         .read(analyzeAndSaveDreamUseCaseProvider)
         .execute(uid, state.dreamContent, state.selectedIndex + 1);
 
-    // 재해석이 아닌 경우 해석 횟수 리셋
-    if (!isReInterpretation) {
-      ref
-          .read(dreamInterpretationViewModelProvider.notifier)
-          .resetInterpretationCount();
-    }
-
     ref.read(dreamInterpretationViewModelProvider.notifier).setDream(dream);
 
     // 작성 후 기록, 통계 갱신

--- a/lib/presentation/dream/view_models/dream_write_view_model.dart
+++ b/lib/presentation/dream/view_models/dream_write_view_model.dart
@@ -24,7 +24,7 @@ class DreamWriteViewModel extends AutoDisposeNotifier<DreamWriteState> {
     state = state.copyWith(isFocused: focused);
   }
 
-  Future<void> submitDream() async {
+  Future<void> submitDream({bool isReInterpretation = false}) async {
     if (state.dreamContent.trim().length < 10) return;
     if (state.selectedIndex == -1) return;
     final uid = await SecureStorageService().getUserIdx();
@@ -33,6 +33,14 @@ class DreamWriteViewModel extends AutoDisposeNotifier<DreamWriteState> {
     final dream = await ref
         .read(analyzeAndSaveDreamUseCaseProvider)
         .execute(uid, state.dreamContent, state.selectedIndex + 1);
+
+    // 재해석이 아닌 경우 해석 횟수 리셋
+    if (!isReInterpretation) {
+      ref
+          .read(dreamInterpretationViewModelProvider.notifier)
+          .resetInterpretationCount();
+    }
+
     ref.read(dreamInterpretationViewModelProvider.notifier).setDream(dream);
 
     // 작성 후 기록, 통계 갱신


### PR DESCRIPTION
### 🚀 개요
- 꿈 해석 후, 해석이 마음에 들지 않으면 다시 작성할 수 있도록 수정

### 🔧 작업 내용
- 꿈 작성부터 로딩, 로딩 결과 페이지에 isFirst 매개변수를 추가
- isFirst가 true라면 다시 작성할 수 있도록 버튼이 2개 표시
- isFirst가 false라면 고마워 버튼만 표시하여 다시 재작성할 수 없도록 구현

### 💡 Issue
Closes #208 

