### PR TITLE
[Dream] 꿈 해석 로직에 따른 UI 변경

### DIFF
--- a/lib/presentation/dream/dream_interpretation_page.dart
+++ b/lib/presentation/dream/dream_interpretation_page.dart
@@ -6,6 +6,7 @@ import 'package:mongbi_app/presentation/common/action_button_row.dart';
 import 'package:mongbi_app/presentation/dream/widgets/custom_button.dart';
 import 'package:mongbi_app/presentation/dream/widgets/dream_section_card.dart';
 import 'package:mongbi_app/presentation/dream/widgets/mongbi_comment_card.dart';
+import 'package:mongbi_app/presentation/home/widgets/completion_bottom_sheet.dart';
 import 'package:mongbi_app/providers/dream_provider.dart';
 
 class DreamInterpretationPage extends ConsumerStatefulWidget {
@@ -67,7 +68,25 @@ class _DreamInterpretationPageState
                       leftText: '음... 아닌데?',
                       rightText: '오 맞아!',
                       onLeftPressed: () {
-                        context.pushReplacement('/dream_write?isFirst=false');
+                        showModalBottomSheet(
+                          context: context,
+                          backgroundColor: Colors.transparent,
+                          isScrollControlled: true,
+                          useRootNavigator: true,
+                          builder:
+                              (context) => CompletionBottomSheet(
+                                title: '앗, 다시 해석해줄게몽',
+                                subTitle: '한 번만 다시 할 수 있습니다.',
+                                buttonText: '다시할게',
+                                mongbiImagePath: 'assets/images/mongbi.webp',
+
+                                onButtonPressed: () {
+                                  context.pushReplacement(
+                                    '/dream_write?isFirst=false',
+                                  );
+                                },
+                              ),
+                        );
                       },
                       onRightPressed:
                           () => context.pushReplacement('/challenge_intro'),

--- a/lib/presentation/home/widgets/challenge_card.dart
+++ b/lib/presentation/home/widgets/challenge_card.dart
@@ -160,6 +160,7 @@ class ChallengeCard extends ConsumerWidget {
                             title: '정말 잘 했어몽!',
                             subTitle: '오늘 하루도 행복했으면 좋겠어요.',
                             buttonText: '고마워',
+                            mongbiImagePath: 'assets/images/happy_mongbi.webp',
                             onButtonPressed: () {
                               context.pop();
                               homeViewModel.completeChallenge(isComplete: true);

--- a/lib/presentation/home/widgets/completion_bottom_sheet.dart
+++ b/lib/presentation/home/widgets/completion_bottom_sheet.dart
@@ -9,12 +9,14 @@ class CompletionBottomSheet extends StatelessWidget {
     required this.title,
     required this.subTitle,
     required this.buttonText,
+    required this.mongbiImagePath,
     required this.onButtonPressed,
   });
 
   final String title;
   final String subTitle;
   final String buttonText;
+  final String mongbiImagePath;
   final VoidCallback onButtonPressed;
 
   @override
@@ -35,16 +37,12 @@ class CompletionBottomSheet extends StatelessWidget {
             style: Font.subTitle12.copyWith(color: Color(0xFF76717A)),
           ),
           SizedBox(height: 8),
-          Image.asset(
-            'assets/images/happy_mongbi.webp',
-            width: 144,
-            height: 144,
-          ),
+          Image.asset(mongbiImagePath, width: 144, height: 144),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 24),
             child: FilledButtonWidget(
               type: ButtonType.primary,
-              text: '고마워',
+              text: buttonText,
               onPress: onButtonPressed,
             ),
           ),


### PR DESCRIPTION
### 🚀 개요
꿈 해석 로직에 따른 UI 변경

### 🔧 작업 내용
- 꿈 해석 처음일 때 '아닌데' 버튼 터치 시 바텀시트 띄우기

### 📸 실행 화면
<img src="https://github.com/user-attachments/assets/f4530b4a-c802-4bef-bcf3-276f688add1c" width="300" height="600"/>


### 💡 Issue
Closes #222
