### PR TITLE
[Auth] 네이버 access 토큰 없음 오류 스낵바 문구 수정

### DIFF
--- a/lib/presentation/auth/viewmodels/auth_view_model.dart
+++ b/lib/presentation/auth/viewmodels/auth_view_model.dart
@@ -84,7 +84,7 @@ class AuthViewModel extends Notifier<User?> {
         accessToken = tokenResult.accessToken;
       }
       if (accessToken.isEmpty) {
-        throw const AuthFailedException('네이버 accessToken 없음');
+        throw const AuthCancelledException('로그인이 취소되었습니다.');
       }
 
       final user = await _loginWithNaver.execute(accessToken);


### PR DESCRIPTION
### 🚀 개요
- 로그인 취소나 탈퇴 하면 스낵바로 네이버 access 토큰 없음 이라고 나오는 메세지 변경

### 🔧 작업 내용
- 사용자에게 AccessToken이 없다는 말보다 로그인이 취소되었습니다 라는 메세지를 표시

### 💡 Issue
Closes #227 

