### PR TITLE
[Challenge] 챌린지 중복 저장 오류

### DIFF
--- a/lib/presentation/challenge/challenge_page.dart
+++ b/lib/presentation/challenge/challenge_page.dart
@@ -165,10 +165,6 @@ class ChallengePage extends ConsumerWidget {
                             .read(challengeViewModelProvider)
                             .value![selectedIndex];
 
-                    await ref
-                        .read(challengeViewModelProvider.notifier)
-                        .saveChallenge();
-
                     await FirebaseAnalytics.instance.logEvent(
                       name: 'challenge_completed',
                       parameters: {
@@ -189,7 +185,11 @@ class ChallengePage extends ConsumerWidget {
                           (context) => MongbiDialog(
                             content: '꿈 잘먹었몽!\n선물 완료하고, 오늘도 힘내라몽',
                             buttonText: '고마워',
-                            onSubmit: () {
+                            onSubmit: () async {
+                              await ref
+                                  .read(challengeViewModelProvider.notifier)
+                                  .saveChallenge();
+
                               context.pushReplacement('/home');
                             },
                           ),


### PR DESCRIPTION
### 🚀 개요
- 챌린지 선택 후 다음 버튼 클릭 시 나타나는 Bottom Sheet를 닫고 재선택하면 챌린지가 중복 저장되는 문제 수정

### 🔧 작업 내용
- 챌린지 화면에서 버튼을 클릭하면 실행되는 저장 로직을 Dialog 버튼을 클릭해야 저장할 수 있도록 수정

### 💡 Issue
Closes #262 

