### PR TITLE
[Setting] 배경음악 오류 수정

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,7 +17,7 @@ void main() async {
   await dotenv.load(fileName: '.env');
   // 캘린더 한글화
   await initializeDateFormatting();
-
+  
 
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
   KakaoSdk.init(
@@ -28,7 +28,7 @@ void main() async {
     (options) {
       options.dsn =
           'https://8d16495c497563cc341db965785f3374@o4509553500422144.ingest.de.sentry.io/4509553530830928';
-  
+
       options.tracesSampleRate = 1.0;
       options.profilesSampleRate = 1.0;
     },
@@ -72,7 +72,10 @@ class _MyAppState extends ConsumerState<MyApp> with WidgetsBindingObserver {
         state == AppLifecycleState.detached) {
       bgm.fadeOutAndPause();
     } else if (state == AppLifecycleState.resumed) {
-      bgm.resumeBgm();
+      final isBgmOn = ref.read(bgmProvider);
+      if (isBgmOn) {
+        bgm.resumeBgm();
+      }
     }
   }
 

--- a/lib/presentation/setting/setting_page.dart
+++ b/lib/presentation/setting/setting_page.dart
@@ -2,7 +2,6 @@ import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:kakao_flutter_sdk/kakao_flutter_sdk.dart';
 import 'package:mongbi_app/core/font.dart';
 import 'package:mongbi_app/presentation/setting/widgets/setting_rounded_list_tile_item.dart';
 import 'package:mongbi_app/presentation/setting/widgets/setting_section_card.dart';

--- a/lib/presentation/setting/setting_page.dart
+++ b/lib/presentation/setting/setting_page.dart
@@ -69,8 +69,10 @@ class _SettingPageState extends ConsumerState<SettingPage> {
                 final toggledOn = !isBgmOn;
                 toggledOn ? bgmNotifier.turnOn() : bgmNotifier.turnOff();
                 FirebaseAnalytics.instance.logEvent(
-                  name: 'bgm_toggled',
-                  parameters: {'enabled': toggledOn},
+                  name: 'bgm_toggle',
+                  parameters: {
+                    'enabled': true.toString(),
+                  },
                 );
               },
             ),

--- a/lib/presentation/setting/setting_page.dart
+++ b/lib/presentation/setting/setting_page.dart
@@ -52,7 +52,7 @@ class _SettingPageState extends ConsumerState<SettingPage> {
       children: [
         UserInfoHeader(
           nickname: splashState.userList![0].userNickname!,
-          loginType: splashState.userList![0].userSocialType!,
+          loginType: splashState.userList![0].userSocialType,
           onTap: () => context.push('/profile_setting'),
         ),
         const SizedBox(height: 24),

--- a/lib/presentation/setting/setting_page.dart
+++ b/lib/presentation/setting/setting_page.dart
@@ -11,7 +11,6 @@ import 'package:mongbi_app/presentation/setting/widgets/setting_user_info_header
 import 'package:mongbi_app/providers/setting_provider.dart';
 import 'package:mongbi_app/providers/user_info_provider.dart';
 import 'package:package_info_plus/package_info_plus.dart';
-import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class SettingPage extends ConsumerStatefulWidget {


### PR DESCRIPTION
### 🚀 개요
- 음악을 꺼도 앱 나갔다 오면, 혹은 이용 약관 눌렀다 돌아오면 다시 음악이 들림

### 🔧 작업 내용
- 앱이 resumed 상태일 때 toggle이 on 되어 있을 때만 음악 실행
- 추가로 Firebase Analytics 타입 수정
- import 문 제거

### 💡 Issue
Closes #261 

