### PR TITLE
[Statistics] 데이터 통신 중 탭 이동이 여러 번 될 경우 AysyncNotifier 통신 중복 에러 발생

### DIFF
--- a/lib/presentation/statistics/statistics_page.dart
+++ b/lib/presentation/statistics/statistics_page.dart
@@ -45,6 +45,7 @@ class _StatisticsPageState extends ConsumerState<StatisticsPage>
     final splashState = ref.watch(splashViewModelProvider);
     final nickname = splashState.userList?[0].userNickname ?? '몽비';
     final snackBarState = ref.watch(snackBarStatusProvider);
+    final statisticsAsync = ref.watch(statisticsViewModelProvider);
 
     return SafeArea(
       child: Stack(
@@ -99,6 +100,8 @@ class _StatisticsPageState extends ConsumerState<StatisticsPage>
               ),
             ),
           ),
+          if (statisticsAsync.isLoading)
+            Center(child: CircularProgressIndicator()),
           if (snackBarState)
             Positioned(bottom: 18, left: 0, right: 0, child: CustomSnackBar()),
         ],

--- a/lib/presentation/statistics/widgets/month_statistics.dart
+++ b/lib/presentation/statistics/widgets/month_statistics.dart
@@ -81,7 +81,7 @@ class _MonthStatisticsState extends ConsumerState<MonthStatistics>
 
                 statisticsAsync.when(
                   loading: () {
-                    return Center(child: CircularProgressIndicator());
+                    return SizedBox();
                   },
                   data: (data) {
                     final monthStatistics = data?.month;
@@ -153,7 +153,6 @@ class _MonthStatisticsState extends ConsumerState<MonthStatistics>
                 ),
               ],
             ),
-            // CustomSnackBar(key: monthSnackBarKey),
           ],
         ),
       ],

--- a/lib/presentation/statistics/widgets/month_year_picker_button.dart
+++ b/lib/presentation/statistics/widgets/month_year_picker_button.dart
@@ -23,12 +23,15 @@ class MonthYearPickerButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final pickerState = ref.watch(pickerViewModelProvider);
+    final statisticsAsync = ref.watch(statisticsViewModelProvider);
 
     return Padding(
       key: isMonth ? monthPickerButton : yearPickerButton,
       padding: EdgeInsets.symmetric(vertical: 8),
       child: GestureDetector(
         onTap: () {
+          if (statisticsAsync.isLoading) return;
+
           final pickerKey = isMonth ? monthPickerKey : yearPickerKey;
           pickerKey.currentState?.show();
         },

--- a/lib/presentation/statistics/widgets/psychology_keyword_chart.dart
+++ b/lib/presentation/statistics/widgets/psychology_keyword_chart.dart
@@ -1,7 +1,6 @@
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:mongbi_app/core/font.dart';
-import 'package:mongbi_app/core/get_responsive_ratio_by_width.dart';
 import 'package:mongbi_app/data/dtos/statistics_dto.dart';
 import 'package:mongbi_app/presentation/statistics/widgets/common_box.dart';
 import 'package:mongbi_app/presentation/statistics/widgets/custom_fl_dot_painter.dart';

--- a/lib/presentation/statistics/widgets/tab_bar_title.dart
+++ b/lib/presentation/statistics/widgets/tab_bar_title.dart
@@ -26,19 +26,25 @@ class TabBarTitle extends StatelessWidget {
         ),
         height: 48,
         child: Consumer(
-          builder: (context, ref, child) {
+          builder: (consumerContext, ref, child) {
+            final statisticsAsync = ref.watch(statisticsViewModelProvider);
             final statisticsVm = ref.read(statisticsViewModelProvider.notifier);
 
             return TabBar(
               controller: tabController,
-              onTap: (value) {
-                ScaffoldMessenger.of(context).hideCurrentSnackBar();
+              onTap: (value) async {
+                if (statisticsAsync.isLoading) {
+                  // 로딩 중이면 탭 이동 막기
+                  tabController.animateTo(statisticsAsync.value!.tabBarIndex);
+                  return;
+                }
+
                 statisticsVm.onChangetabBarIndex(value);
                 ref.read(snackBarStatusProvider.notifier).state = false;
                 if (value == 0) {
-                  statisticsVm.fetchMonthStatistics();
+                  await statisticsVm.fetchMonthStatistics();
                 } else {
-                  statisticsVm.fetchYearStatistics();
+                  await statisticsVm.fetchYearStatistics();
                 }
               },
               tabs: const [Tab(child: Text('월간')), Tab(child: Text('연간'))],

--- a/lib/presentation/statistics/widgets/year_statistics.dart
+++ b/lib/presentation/statistics/widgets/year_statistics.dart
@@ -79,7 +79,7 @@ class _YearStatisticsState extends ConsumerState<YearStatistics>
 
             statisticsAsync.when(
               loading: () {
-                return Center(child: CircularProgressIndicator());
+                return SizedBox();
               },
               data: (data) {
                 final yearStatistics = data?.year;


### PR DESCRIPTION
### 🚀 개요
데이터 통신 중 탭 이동이 여러 번 될 경우 AysyncNotifier 통신 중복 에러 발생

### 🔧 작업 내용
- 통신 중에은 탭바, 년/월 모달창 선택 막기로 해결

### 💡 Issue
Closes #280
