### PR TITLE
[Statistics] 통계 페이지에서 꿈 작성 후 다시 돌아오면 통계 페이지가 업데이트 되지 않는 에러 수정

### DIFF
--- a/lib/presentation/challenge/challenge_intro_page.dart
+++ b/lib/presentation/challenge/challenge_intro_page.dart
@@ -24,7 +24,7 @@ class ChallengeIntroPage extends ConsumerWidget {
                 leftText: '괜찮아',
                 rightText: '선물이 뭐야?',
                 onLeftPressed: () {
-                  context.pushReplacement('/home');
+                  context.go('/home');
                 },
                 onRightPressed: () async {
                   await ref

--- a/lib/presentation/challenge/challenge_page.dart
+++ b/lib/presentation/challenge/challenge_page.dart
@@ -131,7 +131,7 @@ class ChallengePage extends ConsumerWidget {
                             content: '아앗, 아쉬워라\n꿈 잘먹었몽! 오늘도 힘내라몽',
                             buttonText: '고마워',
                             onSubmit: () {
-                              context.pushReplacement('/home');
+                              context.go('/home');
                             },
                           ),
                     );
@@ -174,7 +174,7 @@ class ChallengePage extends ConsumerWidget {
                                   .read(challengeViewModelProvider.notifier)
                                   .saveChallenge();
 
-                              context.pushReplacement('/home');
+                              context.go('/home');
                             },
                           ),
                     );

--- a/lib/presentation/dream/view_models/dream_write_view_model.dart
+++ b/lib/presentation/dream/view_models/dream_write_view_model.dart
@@ -2,8 +2,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mongbi_app/core/secure_storage_service.dart';
 import 'package:mongbi_app/presentation/dream/models/dream_write_state.dart';
 import 'package:mongbi_app/providers/dream_provider.dart';
-import 'package:mongbi_app/providers/history_provider.dart';
-import 'package:mongbi_app/providers/statistics_provider.dart';
 
 class DreamWriteViewModel extends AutoDisposeNotifier<DreamWriteState> {
   @override
@@ -35,10 +33,5 @@ class DreamWriteViewModel extends AutoDisposeNotifier<DreamWriteState> {
         .execute(uid, state.dreamContent, state.selectedIndex + 1);
 
     ref.read(dreamInterpretationViewModelProvider.notifier).setDream(dream);
-
-    // 작성 후 기록, 통계 갱신
-    await ref.read(statisticsViewModelProvider.notifier).fetchMonthStatistics();
-    await ref.read(statisticsViewModelProvider.notifier).fetchYearStatistics();
-    await ref.read(historyViewModelProvider.notifier).fetchUserDreamsHistory();
   }
 }


### PR DESCRIPTION
### 🚀 개요
통계 페이지에서 꿈 작성 후 다시 돌아오면 통계 페이지가 업데이트 되지 않는 에러 수정

### 🔧 작업 내용
- 꿈 분석 중에 기록, 통계 갱신하는 코드 삭제
- context의 스택이 쌓이지 않게 하기 위해 pushReplacement에서 go로 변경

### 💡 Issue
Closes #322 