### PR TITLE
[History] 챌린지 선택 하지 않았을 때 스크롤 포커스 오류 해결

### DIFF
--- a/lib/presentation/history/widgets/history_item.dart
+++ b/lib/presentation/history/widgets/history_item.dart
@@ -42,7 +42,8 @@ class _HistoryItemState extends State<HistoryItem> {
     return MeasureSize(
       onStop: () {
         if (isExpansion) {
-          if (widget.nextItemKey != null) {
+          if (widget.nextItemKey != null &&
+              widget.nextItemKey?.currentContext != null) {
             Scrollable.ensureVisible(
               widget.nextItemKey!.currentContext!,
               duration: Duration(milliseconds: 300),


### PR DESCRIPTION
### 🚀 개요
챌린지 선택 하지 않았을 때 스크롤 포커스 오류 해결

### 🔧 작업 내용
- key가 null-check 하지 못하게 조건 수정

### 💡 Issue
Closes #329 