### PR TITLE
[Dream] 서버 과부화 에러 스낵바 표시

### DIFF
--- a/lib/presentation/dream/dream_analysis_loading_page.dart
+++ b/lib/presentation/dream/dream_analysis_loading_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mongbi_app/core/font.dart';
+import 'package:mongbi_app/presentation/common/custom_snack_bar.dart';
 import 'package:mongbi_app/presentation/common/floating_animation_widget.dart';
 import 'package:mongbi_app/providers/dream_provider.dart';
 
@@ -80,7 +81,8 @@ class _DreamAnalysisLoadingPageState
       if (mounted) {
         ScaffoldMessenger.of(
           context,
-        ).showSnackBar(SnackBar(content: Text('꿈 해석 중 오류가 발생했어요: $e')));
+        ).showSnackBar(customSnackBar('꿈 해석 중 오류가 발생했어요.', 80, 2));
+
         context.pop();
       }
     }

--- a/lib/presentation/dream/dream_analysis_loading_page.dart
+++ b/lib/presentation/dream/dream_analysis_loading_page.dart
@@ -5,6 +5,7 @@ import 'package:mongbi_app/core/font.dart';
 import 'package:mongbi_app/presentation/common/custom_snack_bar.dart';
 import 'package:mongbi_app/presentation/common/floating_animation_widget.dart';
 import 'package:mongbi_app/providers/dream_provider.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 class DreamAnalysisLoadingPage extends ConsumerStatefulWidget {
   const DreamAnalysisLoadingPage({super.key, required this.isFirst});
@@ -77,11 +78,13 @@ class _DreamAnalysisLoadingPageState
           '/dream_analysis_result?isFirst=${widget.isFirst}',
         );
       }
-    } catch (e) {
+    } catch (e, s) {
       if (mounted) {
         ScaffoldMessenger.of(
           context,
         ).showSnackBar(customSnackBar('꿈 해석 중 오류가 발생했어요.', 80, 2));
+
+        await Sentry.captureException(e, stackTrace: s);
 
         context.pop();
       }

--- a/lib/presentation/dream/dream_interpretation_page.dart
+++ b/lib/presentation/dream/dream_interpretation_page.dart
@@ -130,10 +130,4 @@ class _DreamInterpretationPageState
       ),
     );
   }
-
-  void showSnackBar(String message) {
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text(message, style: Font.body14)));
-  }
 }


### PR DESCRIPTION
### 🚀 개요
- 서버 에러가 날 경우, 오류 메세지보다는 사용자가 이해할 수 있을만한 에러 메세지로 수정

### 🔧 작업 내용
- 꿈 해석 화면에서 사용하지 않는 스낵바 표시 메서드 제거
- 스낵바를 customSnackbar로 변경
- 에러 메세지를 그대로 사용자에게 보여주는게 아니라 오류가 발생했다는 메세지 표시
- 오류가 발생하면 sentry에 보고 되도록 설정

### 💡 Issue
Closes #325 
