### PR TITLE
[Core] 반응형 UI

### DIFF
--- a/lib/core/main_scaffold.dart
+++ b/lib/core/main_scaffold.dart
@@ -29,7 +29,14 @@ class MainScaffold extends ConsumerWidget {
       backgroundColor: _buildScaffoldBackgroundColor(location),
       appBar: _buildAppBar(context, location),
       extendBodyBehindAppBar: location.startsWith('/home') ? true : false,
-      body: child,
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          if (constraints.maxWidth >= 480) {
+            return Center(child: SizedBox(width: 480, child: child));
+          }
+          return child;
+        },
+      ),
       bottomNavigationBar: BottomAppBar(
         height: 56,
         padding: EdgeInsets.symmetric(horizontal: 24),
@@ -125,9 +132,7 @@ class MainScaffold extends ConsumerWidget {
   }
 
   Color _buildScaffoldBackgroundColor(String location) {
-    if (location.startsWith('/setting')) {
-      return Color(0xFFFCF6FF);
-    } else if (location.startsWith('/statistics')) {
+    if (location.startsWith('/statistics')) {
       return Color(0xFFFFFFFF);
     }
     return Color(0xFFFAFAFA);
@@ -150,64 +155,69 @@ class MainScaffold extends ConsumerWidget {
   AppBar? _buildAppBar(BuildContext context, String location) {
     if (location.startsWith('/home')) {
       return AppBar(
-        title: Text(
-          'MONGBI',
-          style: Font.title24.copyWith(color: Colors.white),
+        title: Center(
+          child: SizedBox(
+            width:
+                MediaQuery.sizeOf(context).width >= 480 ? 480 : double.infinity,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: Row(
+                children: [
+                  Text(
+                    'MONGBI',
+                    style: Font.title24.copyWith(color: Colors.white),
+                  ),
+                  // TODO : FCM 사용 전까지 숨김
+                  // actions: [
+                  //   IconButton(
+                  //     onPressed: () {
+                  //       context.push('/alarm');
+                  //     },
+                  //     padding: EdgeInsets.only(right: 24),
+                  //     icon: Consumer(
+                  //       builder: (context, ref, child) {
+                  //         final alarmState = ref.watch(alarmViewModelProvider);
+                  //         final alarmList = alarmState.alarmList;
+                  //         final isNotRead =
+                  //             alarmList?.any((e) => e.fcmIsRead == false) ?? false;
+
+                  //         return Stack(
+                  //           clipBehavior: Clip.none,
+                  //           children: [
+                  //             SvgPicture.asset(
+                  //               'assets/icons/bell.svg',
+                  //               width: 24,
+                  //               height: 24,
+                  //               fit: BoxFit.none,
+                  //             ),
+                  //             if (isNotRead)
+                  //               Positioned(
+                  //                 right: 0,
+                  //                 top: 0,
+                  //                 child: Container(
+                  //                   width: 6,
+                  //                   height: 6,
+                  //                   decoration: BoxDecoration(
+                  //                     color: Color(0xFFEA4D57),
+                  //                     shape: BoxShape.circle,
+                  //                   ),
+                  //                 ),
+                  //               ),
+                  //           ],
+                  //         );
+                  //       },
+                  //     ),
+                  //   ),
+                  // ],
+                ],
+              ),
+            ),
+          ),
         ),
         centerTitle: false,
         backgroundColor: Colors.transparent,
-        titleSpacing: 24,
         elevation: 0,
-        // TODO : FCM 사용 전까지 숨김
-        // actions: [
-        //   IconButton(
-        //     onPressed: () {
-        //       context.push('/alarm');
-        //     },
-        //     padding: EdgeInsets.only(right: 24),
-        //     icon: Consumer(
-        //       builder: (context, ref, child) {
-        //         final alarmState = ref.watch(alarmViewModelProvider);
-        //         final alarmList = alarmState.alarmList;
-        //         final isNotRead =
-        //             alarmList?.any((e) => e.fcmIsRead == false) ?? false;
-
-        //         return Stack(
-        //           clipBehavior: Clip.none,
-        //           children: [
-        //             SvgPicture.asset(
-        //               'assets/icons/bell.svg',
-        //               width: 24,
-        //               height: 24,
-        //               fit: BoxFit.none,
-        //             ),
-        //             if (isNotRead)
-        //               Positioned(
-        //                 right: 0,
-        //                 top: 0,
-        //                 child: Container(
-        //                   width: 6,
-        //                   height: 6,
-        //                   decoration: BoxDecoration(
-        //                     color: Color(0xFFEA4D57),
-        //                     shape: BoxShape.circle,
-        //                   ),
-        //                 ),
-        //               ),
-        //           ],
-        //         );
-        //       },
-        //     ),
-        //   ),
-        // ],
-      );
-    } else if (location.startsWith('/setting')) {
-      return AppBar(
-        backgroundColor: Colors.transparent,
-        elevation: 0,
-        titleSpacing: 24,
-        title: Text('마이페이지', style: Font.title20),
-        centerTitle: false,
+        titleSpacing: 0,
       );
     }
 

--- a/lib/core/responsive_layout.dart
+++ b/lib/core/responsive_layout.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+/// 바텀네비게이션바에 연결된 페이지(홈, 기록, 통계, 마이페이지)는 위젯을 그대로 사용
+class ResponsiveLayout extends StatelessWidget {
+  const ResponsiveLayout({super.key, required this.child});
+
+  final Widget child;
+
+  /// 바텀네비게이션바에
+  /// 연결되지 않은 페이지(모달, buildFadeTransitionPage함수 사용하는 페이지, scaffold사용하는 페이지)는
+  /// 정적 메서드 사용
+  static double getWidth(BuildContext context) {
+    final width = MediaQuery.sizeOf(context).width;
+    return width >= 480 ? 480 : double.infinity;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Color(0xFFFFFFFF),
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          if (constraints.maxWidth >= 480) {
+            return Center(child: SizedBox(width: 480, child: child));
+          } else {
+            return child;
+          }
+        },
+      ),
+    );
+  }
+}

--- a/lib/core/router.dart
+++ b/lib/core/router.dart
@@ -3,6 +3,7 @@ import 'package:firebase_analytics/observer.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mongbi_app/core/custom_transition_page.dart';
 import 'package:mongbi_app/core/main_scaffold.dart';
+import 'package:mongbi_app/core/responsive_layout.dart';
 import 'package:mongbi_app/core/route_observer.dart';
 import 'package:mongbi_app/presentation/alarm/alarm_page.dart';
 import 'package:mongbi_app/presentation/auth/social_login_page.dart';
@@ -66,33 +67,37 @@ final GoRouter router = GoRouter(
     GoRoute(path: '/splash', builder: (context, state) => SplashPage()),
     GoRoute(
       path: '/social_login',
-      builder: (context, state) => SocialLoginPage(),
+      builder: (context, state) => ResponsiveLayout(child: SocialLoginPage()),
     ),
     GoRoute(
       path: '/nickname_input',
-      builder: (context, state) => NicknameInputPage(),
+      builder: (context, state) => ResponsiveLayout(child: NicknameInputPage()),
     ),
     GoRoute(
       path: '/remindtime_setting',
-      builder: (context, state) => RemindTimeSettingPage(),
+      builder:
+          (context, state) => ResponsiveLayout(child: RemindTimeSettingPage()),
     ),
 
     GoRoute(
       path: '/remindtime_time_setting',
       builder:
-          (context, state) => RemindTimePickerPage(
-            isRemindEnabled: bool.tryParse(
-              '${state.uri.queryParameters['isRemindEnabled']}',
+          (context, state) => ResponsiveLayout(
+            child: RemindTimePickerPage(
+              isRemindEnabled: bool.tryParse(
+                '${state.uri.queryParameters['isRemindEnabled']}',
+              ),
             ),
           ),
     ),
     GoRoute(
       path: '/onbording_page',
-      builder: (context, state) => OnboardingPage(),
+      builder: (context, state) => ResponsiveLayout(child: OnboardingPage()),
     ),
     GoRoute(
       path: '/onbording_exit_page',
-      builder: (context, state) => OnboardingExitPage(),
+      builder:
+          (context, state) => ResponsiveLayout(child: OnboardingExitPage()),
     ),
     GoRoute(
       path: '/dream_intro',
@@ -141,10 +146,12 @@ final GoRouter router = GoRouter(
     GoRoute(
       path: '/dream_interpretation',
       builder:
-          (context, state) => DreamInterpretationPage(
-            isFirst:
-                bool.tryParse('${state.uri.queryParameters['isFirst']}') ??
-                true,
+          (context, state) => ResponsiveLayout(
+            child: DreamInterpretationPage(
+              isFirst:
+                  bool.tryParse('${state.uri.queryParameters['isFirst']}') ??
+                  true,
+            ),
           ),
     ),
     GoRoute(
@@ -165,16 +172,18 @@ final GoRouter router = GoRouter(
     ),
     GoRoute(
       path: '/profile_setting',
-      builder: (context, state) => ProfileSettingPage(),
+      builder:
+          (context, state) => ResponsiveLayout(child: ProfileSettingPage()),
     ),
     GoRoute(
       path: '/alarm_setting',
-      builder: (context, state) => AlarmSettingPage(),
+      builder: (context, state) => ResponsiveLayout(child: AlarmSettingPage()),
     ),
     GoRoute(path: '/alarm', builder: (context, state) => AlarmPage()),
     GoRoute(
       path: '/license_page',
-      builder: (context, state) => OpenSourceLicensePage(),
+      builder:
+          (context, state) => ResponsiveLayout(child: OpenSourceLicensePage()),
     ),
   ],
 );

--- a/lib/presentation/challenge/challenge_intro_page.dart
+++ b/lib/presentation/challenge/challenge_intro_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mongbi_app/core/responsive_layout.dart';
 import 'package:mongbi_app/presentation/challenge/widgets/challenge_intro_mongbi_message_view.dart';
 import 'package:mongbi_app/presentation/common/action_button_row.dart';
 import 'package:mongbi_app/providers/challenge_provider.dart';
@@ -15,26 +16,31 @@ class ChallengeIntroPage extends ConsumerWidget {
     return Scaffold(
       backgroundColor: Color(0xFFFAFAFA),
       body: SafeArea(
-        child: Column(
-          children: [
-            Expanded(child: MongbiMessageView()),
-            Padding(
-              padding: EdgeInsets.symmetric(horizontal: 24.0, vertical: 8),
-              child: ActionButtonRow(
-                leftText: '괜찮아',
-                rightText: '선물이 뭐야?',
-                onLeftPressed: () {
-                  context.go('/home');
-                },
-                onRightPressed: () async {
-                  await ref
-                      .read(challengeViewModelProvider.notifier)
-                      .loadChallenges(dreamScore);
-                  context.pushReplacement('/challenge');
-                },
-              ),
+        child: Center(
+          child: SizedBox(
+            width: ResponsiveLayout.getWidth(context),
+            child: Column(
+              children: [
+                Expanded(child: MongbiMessageView()),
+                Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 24.0, vertical: 8),
+                  child: ActionButtonRow(
+                    leftText: '괜찮아',
+                    rightText: '선물이 뭐야?',
+                    onLeftPressed: () {
+                      context.go('/home');
+                    },
+                    onRightPressed: () async {
+                      await ref
+                          .read(challengeViewModelProvider.notifier)
+                          .loadChallenges(dreamScore);
+                      context.pushReplacement('/challenge');
+                    },
+                  ),
+                ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/presentation/challenge/challenge_page.dart
+++ b/lib/presentation/challenge/challenge_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mongbi_app/core/analytics/analytics_helper.dart';
 import 'package:mongbi_app/core/font.dart';
+import 'package:mongbi_app/core/responsive_layout.dart';
 import 'package:mongbi_app/presentation/challenge/widgets/challenge_container.dart';
 import 'package:mongbi_app/presentation/challenge/widgets/mongbi_dialog.dart';
 import 'package:mongbi_app/presentation/common/action_button_row.dart';
@@ -21,167 +22,184 @@ class ChallengePage extends ConsumerWidget {
     return Scaffold(
       backgroundColor: const Color(0xFFFAFAFA),
       body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24),
-          child: Column(
-            children: [
-              const SizedBox(height: 24),
-              Text(
-                '선물 골라봐몽!',
-                style: Font.title20.copyWith(color: const Color(0xFF1A181B)),
-              ),
-              Expanded(
-                child: challenges.when(
-                  loading:
-                      () => const Center(child: CircularProgressIndicator()),
-                  error:
-                      (error, stack) =>
-                          Center(child: Text('오류가 발생했습니다: $error')),
-                  data:
-                      (challenges) => Stack(
-                        fit: StackFit.expand,
-                        children: [
-                          if (challenges.length >= 3) ...[
-                            Positioned(
-                              top: 44,
-                              left: 0,
-                              child: GestureDetector(
-                                onTap: () {
-                                  ref
-                                      .read(challengeViewModelProvider.notifier)
-                                      .selectChallenge(0);
-                                  AnalyticsHelper.logEvent('챌린지_선택', {
-                                    '인덱스': 0,
-                                    '타입': challenges[0].type,
-                                    '화면_이름': 'ChallengePage',
-                                  });
-                                },
-                                child: ChallengeContainer(
-                                  title: challenges[0].type,
-                                  content: challenges[0].content,
-                                  containerColor: const Color(0xFFB7EBE5),
-                                  rotationAngle: -0.14,
-                                  isSelected: selectedIndex == 0,
+        child: Center(
+          child: SizedBox(
+            width: ResponsiveLayout.getWidth(context),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: Column(
+                children: [
+                  const SizedBox(height: 24),
+                  Text(
+                    '선물 골라봐몽!',
+                    style: Font.title20.copyWith(
+                      color: const Color(0xFF1A181B),
+                    ),
+                  ),
+                  Expanded(
+                    child: challenges.when(
+                      loading:
+                          () =>
+                              const Center(child: CircularProgressIndicator()),
+                      error:
+                          (error, stack) =>
+                              Center(child: Text('오류가 발생했습니다: $error')),
+                      data:
+                          (challenges) => Stack(
+                            fit: StackFit.expand,
+                            children: [
+                              if (challenges.length >= 3) ...[
+                                Positioned(
+                                  top: 44,
+                                  left: 0,
+                                  child: GestureDetector(
+                                    onTap: () {
+                                      ref
+                                          .read(
+                                            challengeViewModelProvider.notifier,
+                                          )
+                                          .selectChallenge(0);
+                                      AnalyticsHelper.logEvent('챌린지_선택', {
+                                        '인덱스': 0,
+                                        '타입': challenges[0].type,
+                                        '화면_이름': 'ChallengePage',
+                                      });
+                                    },
+                                    child: ChallengeContainer(
+                                      title: challenges[0].type,
+                                      content: challenges[0].content,
+                                      containerColor: const Color(0xFFB7EBE5),
+                                      rotationAngle: -0.14,
+                                      isSelected: selectedIndex == 0,
+                                    ),
+                                  ),
                                 ),
-                              ),
-                            ),
-                            Positioned(
-                              top: 220,
-                              right: 10,
-                              child: GestureDetector(
-                                onTap: () {
-                                  ref
-                                      .read(challengeViewModelProvider.notifier)
-                                      .selectChallenge(1);
-                                  AnalyticsHelper.logEvent('챌린지_선택', {
-                                    '인덱스': 1,
-                                    '타입': challenges[1].type,
-                                    '화면_이름': 'ChallengePage',
-                                  });
-                                },
-                                child: ChallengeContainer(
-                                  title: challenges[1].type,
-                                  content: challenges[1].content,
-                                  containerColor: const Color(0xFF94E2D8),
-                                  rotationAngle: 0.14,
-                                  isSelected: selectedIndex == 1,
+                                Positioned(
+                                  top: 220,
+                                  right: 10,
+                                  child: GestureDetector(
+                                    onTap: () {
+                                      ref
+                                          .read(
+                                            challengeViewModelProvider.notifier,
+                                          )
+                                          .selectChallenge(1);
+                                      AnalyticsHelper.logEvent('챌린지_선택', {
+                                        '인덱스': 1,
+                                        '타입': challenges[1].type,
+                                        '화면_이름': 'ChallengePage',
+                                      });
+                                    },
+                                    child: ChallengeContainer(
+                                      title: challenges[1].type,
+                                      content: challenges[1].content,
+                                      containerColor: const Color(0xFF94E2D8),
+                                      rotationAngle: 0.14,
+                                      isSelected: selectedIndex == 1,
+                                    ),
+                                  ),
                                 ),
-                              ),
-                            ),
-                            Positioned(
-                              top: 410,
-                              left: 10,
-                              child: GestureDetector(
-                                onTap: () {
-                                  ref
-                                      .read(challengeViewModelProvider.notifier)
-                                      .selectChallenge(2);
-                                  AnalyticsHelper.logEvent('챌린지_선택', {
-                                    '인덱스': 2,
-                                    '타입': challenges[2].type,
-                                    '화면_이름': 'ChallengePage',
-                                  });
-                                },
-                                child: ChallengeContainer(
-                                  title: challenges[2].type,
-                                  content: challenges[2].content,
-                                  containerColor: const Color(0xFF64D4C7),
-                                  rotationAngle: -0.14,
-                                  isSelected: selectedIndex == 2,
+                                Positioned(
+                                  top: 410,
+                                  left: 10,
+                                  child: GestureDetector(
+                                    onTap: () {
+                                      ref
+                                          .read(
+                                            challengeViewModelProvider.notifier,
+                                          )
+                                          .selectChallenge(2);
+                                      AnalyticsHelper.logEvent('챌린지_선택', {
+                                        '인덱스': 2,
+                                        '타입': challenges[2].type,
+                                        '화면_이름': 'ChallengePage',
+                                      });
+                                    },
+                                    child: ChallengeContainer(
+                                      title: challenges[2].type,
+                                      content: challenges[2].content,
+                                      containerColor: const Color(0xFF64D4C7),
+                                      rotationAngle: -0.14,
+                                      isSelected: selectedIndex == 2,
+                                    ),
+                                  ),
                                 ),
-                              ),
-                            ),
-                          ] else
-                            const Center(child: Text('챌린지가 부족합니다.')),
-                        ],
-                      ),
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(vertical: 8),
-                child: ActionButtonRow(
-                  leftText: '흠 안할래',
-                  rightText: '이걸로 할래',
-                  onLeftPressed: () {
-                    AnalyticsHelper.logButtonClick('챌린지_취소', 'ChallengePage');
-                    showDialog(
-                      context: context,
-                      builder:
-                          (context) => MongbiDialog(
-                            content: '아앗, 아쉬워라\n꿈 잘먹었몽! 오늘도 힘내라몽',
-                            buttonText: '고마워',
-                            onSubmit: () {
-                              context.go('/home');
-                            },
+                              ] else
+                                const Center(child: Text('챌린지가 부족합니다.')),
+                            ],
                           ),
-                    );
-                  },
-                  onRightPressed: () async {
-                    if (selectedIndex == null) {
-                      await AnalyticsHelper.logEvent('챌린지_미선택', {
-                        '화면_이름': 'ChallengePage',
-                      });
-                      ScaffoldMessenger.of(
-                        context,
-                      ).showSnackBar(customSnackBar('선물을 먼저 골라줘', 80, 2));
-                      return;
-                    }
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 8),
+                    child: ActionButtonRow(
+                      leftText: '흠 안할래',
+                      rightText: '이걸로 할래',
+                      onLeftPressed: () {
+                        AnalyticsHelper.logButtonClick(
+                          '챌린지_취소',
+                          'ChallengePage',
+                        );
+                        showDialog(
+                          context: context,
+                          builder:
+                              (context) => MongbiDialog(
+                                content: '아앗, 아쉬워라\n꿈 잘먹었몽! 오늘도 힘내라몽',
+                                buttonText: '고마워',
+                                onSubmit: () {
+                                  context.go('/home');
+                                },
+                              ),
+                        );
+                      },
+                      onRightPressed: () async {
+                        if (selectedIndex == null) {
+                          await AnalyticsHelper.logEvent('챌린지_미선택', {
+                            '화면_이름': 'ChallengePage',
+                          });
+                          ScaffoldMessenger.of(
+                            context,
+                          ).showSnackBar(customSnackBar('선물을 먼저 골라줘', 80, 2));
+                          return;
+                        }
 
-                    final selectedChallenge =
-                        ref
-                            .read(challengeViewModelProvider)
-                            .value![selectedIndex];
+                        final selectedChallenge =
+                            ref
+                                .read(challengeViewModelProvider)
+                                .value![selectedIndex];
 
-                    await AnalyticsHelper.logEvent('챌린지_완료', {
-                      '인덱스': selectedIndex,
-                      '타입': selectedChallenge.type,
-                      '화면_이름': 'ChallengePage',
-                    });
+                        await AnalyticsHelper.logEvent('챌린지_완료', {
+                          '인덱스': selectedIndex,
+                          '타입': selectedChallenge.type,
+                          '화면_이름': 'ChallengePage',
+                        });
 
-                    await AnalyticsHelper.logEvent('유저_속성_설정', {
-                      '속성_이름': 'challenge_type',
-                      '속성_값': selectedChallenge.type,
-                    });
+                        await AnalyticsHelper.logEvent('유저_속성_설정', {
+                          '속성_이름': 'challenge_type',
+                          '속성_값': selectedChallenge.type,
+                        });
 
-                    await showDialog(
-                      context: context,
-                      builder:
-                          (context) => MongbiDialog(
-                            content: '꿈 잘먹었몽!\n선물 완료하고, 오늘도 힘내라몽',
-                            buttonText: '고마워',
-                            onSubmit: () async {
-                              await ref
-                                  .read(challengeViewModelProvider.notifier)
-                                  .saveChallenge();
+                        await showDialog(
+                          context: context,
+                          builder:
+                              (context) => MongbiDialog(
+                                content: '꿈 잘먹었몽!\n선물 완료하고, 오늘도 힘내라몽',
+                                buttonText: '고마워',
+                                onSubmit: () async {
+                                  await ref
+                                      .read(challengeViewModelProvider.notifier)
+                                      .saveChallenge();
 
-                              context.go('/home');
-                            },
-                          ),
-                    );
-                  },
-                ),
+                                  context.go('/home');
+                                },
+                              ),
+                        );
+                      },
+                    ),
+                  ),
+                ],
               ),
-            ],
+            ),
           ),
         ),
       ),

--- a/lib/presentation/challenge/widgets/mongbi_dialog.dart
+++ b/lib/presentation/challenge/widgets/mongbi_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mongbi_app/core/font.dart';
+import 'package:mongbi_app/core/responsive_layout.dart';
 import 'package:mongbi_app/presentation/auth/widgets/mongbi_image_widget.dart';
 import 'package:mongbi_app/presentation/dream/widgets/custom_button.dart';
 
@@ -18,7 +19,10 @@ class MongbiDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Dialog(
+      insetPadding: EdgeInsets.zero,
+      backgroundColor: Colors.transparent,
       child: Container(
+        width: ResponsiveLayout.getWidth(context),
         decoration: BoxDecoration(
           color: Colors.white,
           borderRadius: BorderRadius.circular(24),

--- a/lib/presentation/dream/dream_analysis_loading_page.dart
+++ b/lib/presentation/dream/dream_analysis_loading_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mongbi_app/core/font.dart';
+import 'package:mongbi_app/core/responsive_layout.dart';
 import 'package:mongbi_app/presentation/common/custom_snack_bar.dart';
 import 'package:mongbi_app/presentation/common/floating_animation_widget.dart';
 import 'package:mongbi_app/providers/dream_provider.dart';
@@ -31,38 +32,41 @@ class _DreamAnalysisLoadingPageState
     final screenHeight = MediaQuery.of(context).size.height;
 
     return Scaffold(
-      body: Container(
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
-            colors: [
-              Color(0xFFFBC8FF).withValues(alpha: 0.4),
-              Color(0xFFAE7CFF).withValues(alpha: 0.4),
-              Color(0xFF37DAFF).withValues(alpha: 0.4),
-            ],
-            stops: [0.0, 0.5, 1.0],
-          ),
-        ),
-        child: SafeArea(
-          child: Center(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  '꿈 해석 중이야\n잠시만 기다려몽',
-                  textAlign: TextAlign.center,
-                  style: Font.title20,
-                ),
-                const SizedBox(height: 40),
-                FloatingAnimationWidget(
-                  child: Image.asset(
-                    'assets/images/splash_mongbi.webp',
-                    width: screenHeight * 0.28,
-                    height: screenHeight * 0.28,
-                  ),
-                ),
+      body: Center(
+        child: Container(
+          width: ResponsiveLayout.getWidth(context),
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: [
+                Color(0xFFFBC8FF).withValues(alpha: 0.4),
+                Color(0xFFAE7CFF).withValues(alpha: 0.4),
+                Color(0xFF37DAFF).withValues(alpha: 0.4),
               ],
+              stops: [0.0, 0.5, 1.0],
+            ),
+          ),
+          child: SafeArea(
+            child: Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    '꿈 해석 중이야\n잠시만 기다려몽',
+                    textAlign: TextAlign.center,
+                    style: Font.title20,
+                  ),
+                  const SizedBox(height: 40),
+                  FloatingAnimationWidget(
+                    child: Image.asset(
+                      'assets/images/splash_mongbi.webp',
+                      width: screenHeight * 0.28,
+                      height: screenHeight * 0.28,
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/presentation/dream/dream_analysis_result_page.dart
+++ b/lib/presentation/dream/dream_analysis_result_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mongbi_app/core/font.dart';
+import 'package:mongbi_app/core/responsive_layout.dart';
 import 'package:mongbi_app/presentation/common/floating_animation_widget.dart';
 
 class DreamAnalysisResultPage extends StatefulWidget {
@@ -32,34 +33,37 @@ class _DreamAnalysisResultPageState extends State<DreamAnalysisResultPage> {
     final screenHeight = MediaQuery.of(context).size.height;
 
     return Scaffold(
-      body: Container(
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
-            colors: [Color(0xFFFFFDFF), Color(0xFFEFD3FF), Color(0xFFD1FFFD)],
-            stops: [0.0, 0.5, 1.0],
+      body: Center(
+        child: Container(
+          width: ResponsiveLayout.getWidth(context),
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: [Color(0xFFFFFDFF), Color(0xFFEFD3FF), Color(0xFFD1FFFD)],
+              stops: [0.0, 0.5, 1.0],
+            ),
           ),
-        ),
-        child: SafeArea(
-          child: Center(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  '다됐다몽!\n',
-                  textAlign: TextAlign.center,
-                  style: Font.title20,
-                ),
-                const SizedBox(height: 40),
-                FloatingAnimationWidget(
-                  child: Image.asset(
-                    'assets/images/splash_mongbi.webp',
-                    width: screenHeight * 0.28,
-                    height: screenHeight * 0.28,
+          child: SafeArea(
+            child: Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    '다됐다몽!\n',
+                    textAlign: TextAlign.center,
+                    style: Font.title20,
                   ),
-                ),
-              ],
+                  const SizedBox(height: 40),
+                  FloatingAnimationWidget(
+                    child: Image.asset(
+                      'assets/images/splash_mongbi.webp',
+                      width: screenHeight * 0.28,
+                      height: screenHeight * 0.28,
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/presentation/dream/dream_intro_page.dart
+++ b/lib/presentation/dream/dream_intro_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mongbi_app/core/font.dart';
+import 'package:mongbi_app/core/responsive_layout.dart';
 import 'package:mongbi_app/presentation/common/floating_animation_widget.dart';
 
 class DreamIntroPage extends StatefulWidget {
@@ -27,34 +28,37 @@ class _DreamAnalysisResultPageState extends State<DreamIntroPage> {
     final screenHeight = MediaQuery.of(context).size.height;
 
     return Scaffold(
-      body: Container(
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
-            colors: [Color(0xFFFFFDFF), Color(0xFFEFD3FF), Color(0xFFD1FFFD)],
-            stops: [0.0, 0.5, 1.0],
+      body: Center(
+        child: Container(
+          width: ResponsiveLayout.getWidth(context),
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: [Color(0xFFFFFDFF), Color(0xFFEFD3FF), Color(0xFFD1FFFD)],
+              stops: [0.0, 0.5, 1.0],
+            ),
           ),
-        ),
-        child: SafeArea(
-          child: Center(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  '오늘은 어떤 꿈을 꿨몽?\n',
-                  textAlign: TextAlign.center,
-                  style: Font.title20,
-                ),
-                const SizedBox(height: 40),
-                FloatingAnimationWidget(
-                  child: Image.asset(
-                    'assets/images/splash_mongbi.webp',
-                    width: screenHeight * 0.28,
-                    height: screenHeight * 0.28,
+          child: SafeArea(
+            child: Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    '오늘은 어떤 꿈을 꿨몽?\n',
+                    textAlign: TextAlign.center,
+                    style: Font.title20,
                   ),
-                ),
-              ],
+                  const SizedBox(height: 40),
+                  FloatingAnimationWidget(
+                    child: Image.asset(
+                      'assets/images/splash_mongbi.webp',
+                      width: screenHeight * 0.28,
+                      height: screenHeight * 0.28,
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/presentation/dream/dream_write_page.dart
+++ b/lib/presentation/dream/dream_write_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mongbi_app/core/font.dart';
+import 'package:mongbi_app/core/responsive_layout.dart';
 import 'package:mongbi_app/presentation/common/button_type.dart';
 import 'package:mongbi_app/presentation/common/filled_button_widget.dart';
 import 'package:mongbi_app/presentation/dream/widgets/dream_content_input.dart';
@@ -47,69 +48,74 @@ class _DreamWritePageState extends ConsumerState<DreamWritePage> {
     return Scaffold(
       backgroundColor: Colors.grey[50],
       resizeToAvoidBottomInset: true,
-      body: SafeArea(
-        child: GestureDetector(
-          onTap: () => FocusScope.of(context).unfocus(),
-          child: CustomScrollView(
-            slivers: [
-              SliverAppBar(
-                expandedHeight: 0,
-                backgroundColor: Colors.grey[50],
-                leading: IconButton(
-                  icon: Icon(Icons.arrow_back),
-                  onPressed: () {
-                    Navigator.pop(context);
-                  },
-                ),
-              ),
-              SliverToBoxAdapter(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 24),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      // 꿈 내용 입력 필드
-                      Text('오늘 꿈 내용은', style: Font.title18),
-                      const SizedBox(height: 8),
-                      DreamContentInput(focusNode: _focusNode),
-                      const SizedBox(height: 72),
+      body: Center(
+        child: SizedBox(
+          width: ResponsiveLayout.getWidth(context),
+          child: SafeArea(
+            child: GestureDetector(
+              onTap: () => FocusScope.of(context).unfocus(),
+              child: CustomScrollView(
+                slivers: [
+                  SliverAppBar(
+                    expandedHeight: 0,
+                    backgroundColor: Colors.grey[50],
+                    leading: IconButton(
+                      icon: Icon(Icons.arrow_back),
+                      onPressed: () {
+                        Navigator.pop(context);
+                      },
+                    ),
+                  ),
+                  SliverToBoxAdapter(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 24),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          // 꿈 내용 입력 필드
+                          Text('오늘 꿈 내용은', style: Font.title18),
+                          const SizedBox(height: 8),
+                          DreamContentInput(focusNode: _focusNode),
+                          const SizedBox(height: 72),
 
-                      // 기분 선택 아이콘 행 위젯
-                      Text('꿈을 꾸고 내 기분은', style: Font.title18),
-                      const SizedBox(height: 16),
-                      const MoodSelectionRow(),
-                      SizedBox(height: 50),
-                    ],
-                  ),
-                ),
-              ),
-              SliverFillRemaining(
-                hasScrollBody: false,
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 24),
-                  child: Column(
-                    children: [
-                      const Spacer(),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(vertical: 8),
-                        child: FilledButtonWidget(
-                          type: ButtonType.primary,
-                          text: '내가 꾼 꿈이야',
-                          onPress:
-                              isButtonEnabled
-                                  ? () {
-                                    context.pushReplacement(
-                                      '/dream_analysis_loading?isFirst=${widget.isFirst}',
-                                    );
-                                  }
-                                  : null,
-                        ),
+                          // 기분 선택 아이콘 행 위젯
+                          Text('꿈을 꾸고 내 기분은', style: Font.title18),
+                          const SizedBox(height: 16),
+                          const MoodSelectionRow(),
+                          SizedBox(height: 50),
+                        ],
                       ),
-                    ],
+                    ),
                   ),
-                ),
+                  SliverFillRemaining(
+                    hasScrollBody: false,
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 24),
+                      child: Column(
+                        children: [
+                          const Spacer(),
+                          Padding(
+                            padding: const EdgeInsets.symmetric(vertical: 8),
+                            child: FilledButtonWidget(
+                              type: ButtonType.primary,
+                              text: '내가 꾼 꿈이야',
+                              onPress:
+                                  isButtonEnabled
+                                      ? () {
+                                        context.pushReplacement(
+                                          '/dream_analysis_loading?isFirst=${widget.isFirst}',
+                                        );
+                                      }
+                                      : null,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
               ),
-            ],
+            ),
           ),
         ),
       ),

--- a/lib/presentation/history/widgets/calendar.dart
+++ b/lib/presentation/history/widgets/calendar.dart
@@ -20,13 +20,10 @@ class Calendar extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final calendarState = ref.watch(calendarViewModelProvider);
     final calendarVm = ref.read(calendarViewModelProvider.notifier);
-    final deviceSize = MediaQuery.of(context).size;
-    final double calendarWidth = deviceSize.width - horizontalPadding * 2;
-    final double cellWidth = calendarWidth / 7; // 375기준 46.7
-    final double cellHeight = cellWidth * 1.63; // 375기준 76
-    final double circleWidth = cellWidth * 0.86; // 375기준 40
-    final double daysOfWeekHeight = cellHeight * 0.56;
-    final double fontViewWidth = deviceSize.width * 0.038;
+    final double cellWidth = 46.7; // 375기준 46.7
+    final double cellHeight = 76; // 375기준 76
+    final double circleWidth = 40; // 375기준 40
+    final double daysOfWeekHeight = 40; // 375기준 40
 
     return TableCalendar(
       locale: 'ko_KR',
@@ -67,16 +64,16 @@ class Calendar extends ConsumerWidget {
           return CalendarCell(
             day: day,
             isSelected: false,
+            cellWidth: cellWidth,
             circleWidth: circleWidth,
-            fontViewWidth: fontViewWidth,
           );
         },
         selectedBuilder: (context, day, focusedDay) {
           return CalendarCell(
             day: day,
             isSelected: true,
+            cellWidth: cellWidth,
             circleWidth: circleWidth,
-            fontViewWidth: fontViewWidth,
           );
         },
       ),

--- a/lib/presentation/history/widgets/calendar_bottom_sheet.dart
+++ b/lib/presentation/history/widgets/calendar_bottom_sheet.dart
@@ -1,18 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mongbi_app/core/responsive_layout.dart';
 import 'package:mongbi_app/presentation/history/models/calendar_model.dart';
 import 'package:mongbi_app/presentation/history/widgets/calendar_bottom_sheet_month_selector.dart';
 import 'package:mongbi_app/presentation/history/widgets/calendar_bottom_sheet_year_selector.dart';
 import 'package:mongbi_app/providers/history_provider.dart';
 
-class MonthBottomSheet extends ConsumerStatefulWidget {
-  const MonthBottomSheet({super.key});
+class CalendarBottomSheet extends ConsumerStatefulWidget {
+  const CalendarBottomSheet({super.key});
 
   @override
-  ConsumerState<MonthBottomSheet> createState() => _MonthBottomSheetState();
+  ConsumerState<CalendarBottomSheet> createState() =>
+      _CalendarBottomSheetState();
 }
 
-class _MonthBottomSheetState extends ConsumerState<MonthBottomSheet> {
+class _CalendarBottomSheetState extends ConsumerState<CalendarBottomSheet> {
   late CalendarModel localCalendarState;
   late int minYear;
   late int maxYear;
@@ -59,7 +61,7 @@ class _MonthBottomSheetState extends ConsumerState<MonthBottomSheet> {
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: double.infinity,
+      width: ResponsiveLayout.getWidth(context),
       height: 282,
       padding: EdgeInsets.only(top: 24, bottom: 24 + 34, left: 24, right: 24),
       decoration: BoxDecoration(

--- a/lib/presentation/history/widgets/calendar_cell.dart
+++ b/lib/presentation/history/widgets/calendar_cell.dart
@@ -10,14 +10,14 @@ class CalendarCell extends ConsumerWidget {
     super.key,
     required this.day,
     required this.isSelected,
+    required this.cellWidth,
     required this.circleWidth,
-    required this.fontViewWidth,
   });
 
   final DateTime day;
   final bool isSelected;
+  final double cellWidth;
   final double circleWidth;
-  final double fontViewWidth;
   final Map<String, String> iconPathMap = const {
     '1': 'assets/icons/very_bad.svg',
     '2': 'assets/icons/bad.svg',
@@ -35,7 +35,7 @@ class CalendarCell extends ConsumerWidget {
       iconPath = iconPathMap['${searchedHistory.first.dreamScore}'];
     }
     return Container(
-      width: double.infinity,
+      width: cellWidth,
       decoration: BoxDecoration(
         color: isSelected ? Color(0xFF3B136B) : null,
         borderRadius: isSelected ? BorderRadius.circular(999) : null,
@@ -59,7 +59,6 @@ class CalendarCell extends ConsumerWidget {
           Text(
             '${day.day}',
             style: Font.subTitle14.copyWith(
-              fontSize: fontViewWidth,
               color: isSelected ? Colors.white : Color(0xFFB273FF),
             ),
           ),

--- a/lib/presentation/history/widgets/calendar_change_button.dart
+++ b/lib/presentation/history/widgets/calendar_change_button.dart
@@ -26,7 +26,7 @@ class CalendarChangeButton extends ConsumerWidget {
                 isScrollControlled: true,
                 context: context,
                 builder: (context) {
-                  return Wrap(children: [MonthBottomSheet()]);
+                  return Wrap(children: [CalendarBottomSheet()]);
                 },
               );
             },

--- a/lib/presentation/setting/setting_page.dart
+++ b/lib/presentation/setting/setting_page.dart
@@ -43,104 +43,140 @@ class _SettingPageState extends ConsumerState<SettingPage> {
     final bgmNotifier = ref.read(bgmProvider.notifier);
     final splashState = ref.watch(splashViewModelProvider);
 
-    return ListView(
-      padding: const EdgeInsets.symmetric(horizontal: 24),
+    return Column(
       children: [
-        UserInfoHeader(
-          nickname: splashState.userList![0].userNickname!,
-          loginType: splashState.userList![0].userSocialType,
-          onTap: () => context.push('/profile_setting'),
-        ),
-        const SizedBox(height: 24),
-        SectionCard(
-          title: '설정',
-          children: [
-            RoundedListTileItem(
-              title: '배경음악',
-              isFirst: true,
-              isLast: false,
-              trailing: ToggleSwitch(value: isBgmOn),
-              onTap: () {
-                final toggledOn = !isBgmOn;
-                toggledOn ? bgmNotifier.turnOn() : bgmNotifier.turnOff();
-                AnalyticsHelper.logEvent(
-                  '배경음악_토글',
-                  {
-                    '활성화': toggledOn.toString(),
-                    '화면_이름': '설정_페이지',
-                  },
-                );
-              },
-            ),
-            RoundedListTileItem(
-              title: '알림 설정',
-              isFirst: false,
-              isLast: true,
-              onTap: () {
-                AnalyticsHelper.logButtonClick('알림_설정_열림', '설정_페이지');
-
-                context.push('/alarm_setting');
-              },
-            ),
-          ],
-        ),
-        const SizedBox(height: 16),
-        SectionCard(
-          title: '기타',
-          children: [
-            RoundedListTileItem(
-              title: '고객센터',
-              isFirst: false,
-              isLast: true,
-              onTap: () async {
-                await AnalyticsHelper.logButtonClick('고객센터_열림', '설정_페이지');
-                await launchUrl(Uri.parse('http://pf.kakao.com/_VGzxin'));
-              },
-            ),
-            RoundedListTileItem(
-              title: '이용 약관',
-              isFirst: true,
-              isLast: false,
-              onTap: () {
-                AnalyticsHelper.logButtonClick('이용약관_열림', '설정_페이지');
-
-                final uri = Uri.parse(
-                  'https://destiny-yam-088.notion.site/MONGBI-21b1c082f0ac804a8de8f5e499b00078?source=copy_link',
-                );
-                launchUrl(uri);
-              },
-            ),
-            RoundedListTileItem(
-              title: '오픈소스 라이선스',
-              isFirst: false,
-              isLast: false,
-              onTap: () {
-                AnalyticsHelper.logButtonClick('오픈소스_라이선스_열림', '설정_페이지');
-                context.push('/license_page');
-              },
-            ),
-            RoundedListTileItem(
-              title: '버전 정보',
-              isFirst: false,
-              isLast: true,
-              trailing: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    _version.isEmpty ? '0.0.0' : _version,
-                    style: Font.body16.copyWith(color: const Color(0xFF8C2EFF)),
-                  ),
-                  const SizedBox(width: 8),
-                ],
+        AppBar(
+          title: Center(
+            child: SizedBox(
+              width:
+                  MediaQuery.sizeOf(context).width >= 480
+                      ? 480
+                      : double.infinity,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                child: Row(children: [Text('마이페이지', style: Font.title20)]),
               ),
-              onTap: () {
-                AnalyticsHelper.logButtonClick('버전_정보_탭', '설정_페이지');
-              },
             ),
-          ],
+          ),
+          backgroundColor: Color(0xFFFCF6FF),
+          elevation: 0,
+          titleSpacing: 0,
+          centerTitle: false,
+          automaticallyImplyLeading: false,
+        ),
+        Expanded(
+          child: Container(
+            color: Color(0xFFFCF6FF),
+            child: ListView(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              children: [
+                UserInfoHeader(
+                  nickname: splashState.userList![0].userNickname!,
+                  loginType: splashState.userList![0].userSocialType,
+                  onTap: () => context.push('/profile_setting'),
+                ),
+                const SizedBox(height: 24),
+                SectionCard(
+                  title: '설정',
+                  children: [
+                    RoundedListTileItem(
+                      title: '배경음악',
+                      isFirst: true,
+                      isLast: false,
+                      trailing: ToggleSwitch(value: isBgmOn),
+                      onTap: () {
+                        final toggledOn = !isBgmOn;
+                        toggledOn
+                            ? bgmNotifier.turnOn()
+                            : bgmNotifier.turnOff();
+                        AnalyticsHelper.logEvent('배경음악_토글', {
+                          '활성화': toggledOn.toString(),
+                          '화면_이름': '설정_페이지',
+                        });
+                      },
+                    ),
+                    RoundedListTileItem(
+                      title: '알림 설정',
+                      isFirst: false,
+                      isLast: true,
+                      onTap: () {
+                        AnalyticsHelper.logButtonClick('알림_설정_열림', '설정_페이지');
+
+                        context.push('/alarm_setting');
+                      },
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                SectionCard(
+                  title: '기타',
+                  children: [
+                    RoundedListTileItem(
+                      title: '고객센터',
+                      isFirst: false,
+                      isLast: true,
+                      onTap: () async {
+                        await AnalyticsHelper.logButtonClick(
+                          '고객센터_열림',
+                          '설정_페이지',
+                        );
+                        await launchUrl(
+                          Uri.parse('http://pf.kakao.com/_VGzxin'),
+                        );
+                      },
+                    ),
+                    RoundedListTileItem(
+                      title: '이용 약관',
+                      isFirst: true,
+                      isLast: false,
+                      onTap: () {
+                        AnalyticsHelper.logButtonClick('이용약관_열림', '설정_페이지');
+
+                        final uri = Uri.parse(
+                          'https://destiny-yam-088.notion.site/MONGBI-21b1c082f0ac804a8de8f5e499b00078?source=copy_link',
+                        );
+                        launchUrl(uri);
+                      },
+                    ),
+                    RoundedListTileItem(
+                      title: '오픈소스 라이선스',
+                      isFirst: false,
+                      isLast: false,
+                      onTap: () {
+                        AnalyticsHelper.logButtonClick(
+                          '오픈소스_라이선스_열림',
+                          '설정_페이지',
+                        );
+                        context.push('/license_page');
+                      },
+                    ),
+                    RoundedListTileItem(
+                      title: '버전 정보',
+                      isFirst: false,
+                      isLast: true,
+                      trailing: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(
+                            _version.isEmpty ? '0.0.0' : _version,
+                            style: Font.body16.copyWith(
+                              color: const Color(0xFF8C2EFF),
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                        ],
+                      ),
+                      onTap: () {
+                        AnalyticsHelper.logButtonClick('버전_정보_탭', '설정_페이지');
+                      },
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
         ),
       ],
     );
   }
 }
-

--- a/lib/presentation/setting/widgets/logout_account_modal.dart
+++ b/lib/presentation/setting/widgets/logout_account_modal.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mongbi_app/core/analytics/analytics_helper.dart';
+import 'package:mongbi_app/core/responsive_layout.dart';
 import 'package:mongbi_app/presentation/common/button_type.dart';
 import 'package:mongbi_app/presentation/common/filled_button_widget.dart';
 import 'package:mongbi_app/presentation/common/ghost_button_widget.dart';
@@ -15,121 +16,135 @@ class LogoutAccontModal extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return DefaultTextStyle(
       style: TextStyle(),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 24),
-        child: Container(
-          width: double.infinity,
-          alignment: Alignment.center,
-          child: Container(
-            padding: EdgeInsets.only(top: 32, bottom: 16),
-            width: double.infinity,
-            decoration: BoxDecoration(
-              color: Colors.white,
-              borderRadius: BorderRadius.circular(24),
-            ),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  '로그아웃하시겠어요?',
-                  style: TextStyle(
-                    fontFamily: 'NanumSquareRound',
-                    fontWeight: FontWeight.w800,
-                    fontSize: 18,
-                    height: 24 / 18,
-                    color: Color(0xff1A181B),
-                  ),
-                  textAlign: TextAlign.center,
+      child: Center(
+        child: SizedBox(
+          width: ResponsiveLayout.getWidth(context),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            child: Container(
+              width: double.infinity,
+              alignment: Alignment.center,
+              child: Container(
+                padding: EdgeInsets.only(top: 32, bottom: 16),
+                width: double.infinity,
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(24),
                 ),
-                SizedBox(height: 16),
-                Padding(
-                  padding: const EdgeInsets.symmetric(
-                    vertical: 8,
-                    horizontal: 24,
-                  ),
-                  child: Row(
-                    children: [
-                      Expanded(
-                        child: GhostButtonWidget(
-                          type: ButtonType.primary,
-                          text: '취소',
-                          onPress: () {
-                            context.pop();
-                          },
-                        ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      '로그아웃하시겠어요?',
+                      style: TextStyle(
+                        fontFamily: 'NanumSquareRound',
+                        fontWeight: FontWeight.w800,
+                        fontSize: 18,
+                        height: 24 / 18,
+                        color: Color(0xff1A181B),
                       ),
+                      textAlign: TextAlign.center,
+                    ),
+                    SizedBox(height: 16),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(
+                        vertical: 8,
+                        horizontal: 24,
+                      ),
+                      child: Row(
+                        children: [
+                          Expanded(
+                            child: GhostButtonWidget(
+                              type: ButtonType.primary,
+                              text: '취소',
+                              onPress: () {
+                                context.pop();
+                              },
+                            ),
+                          ),
 
-                      SizedBox(width: 8),
-                      Expanded(
-                        child: FilledButtonWidget(
-                          type: ButtonType.primary,
-                          text: '로그아웃',
-                          onPress: () async {
-                            final prefs = await SharedPreferences.getInstance();
-                            final loginType = prefs.getString('lastLoginType');
-                            bool success = false;
-
-                            try {
-                              if (loginType == 'naver') {
-                                success =
-                                    await ref
-                                        .read(
-                                          auth2.authViewModelProvider.notifier,
-                                        )
-                                        .logoutWithNaver();
-                              } else if (loginType == 'kakao') {
-                                success =
-                                    await ref
-                                        .read(
-                                          auth2.authViewModelProvider.notifier,
-                                        )
-                                        .logoutWithKakao();
-                              } else if (loginType == 'apple') {
-                                success =
-                                    await ref
-                                        .read(
-                                          auth2.authViewModelProvider.notifier,
-                                        )
-                                        .logoutWithApple();
-                              }
-
-                              if (success && context.mounted) {
-                                await AnalyticsHelper.logEvent('로그아웃_성공', {
-                                  '로그인_방식': loginType ?? '알수없음',
-                                  '화면_이름': '로그아웃_모달',
-                                });
-                                context.go('/social_login');
-                              } else {
-                                await AnalyticsHelper.logEvent('로그아웃_실패', {
-                                  '에러': '로그아웃_실패_또는_컨텍스트_언마운트됨',
-                                  '화면_이름': '로그아웃_모달',
-                                });
-                                Navigator.pop(context);
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  const SnackBar(
-                                    content: Text('로그아웃에 실패했습니다.'),
-                                  ),
+                          SizedBox(width: 8),
+                          Expanded(
+                            child: FilledButtonWidget(
+                              type: ButtonType.primary,
+                              text: '로그아웃',
+                              onPress: () async {
+                                final prefs =
+                                    await SharedPreferences.getInstance();
+                                final loginType = prefs.getString(
+                                  'lastLoginType',
                                 );
-                              }
-                            } catch (e) {
-                              await AnalyticsHelper.logEvent('로그아웃_실패', {
-                                '에러': e.toString(),
-                                '화면_이름': '로그아웃_모달',
-                              });
-                              Navigator.pop(context);
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                const SnackBar(
-                                  content: Text('로그아웃 중 오류가 발생했습니다.'),
-                                ),
-                              );
-                            }
-                          },
-                        ),
+                                bool success = false;
+
+                                try {
+                                  if (loginType == 'naver') {
+                                    success =
+                                        await ref
+                                            .read(
+                                              auth2
+                                                  .authViewModelProvider
+                                                  .notifier,
+                                            )
+                                            .logoutWithNaver();
+                                  } else if (loginType == 'kakao') {
+                                    success =
+                                        await ref
+                                            .read(
+                                              auth2
+                                                  .authViewModelProvider
+                                                  .notifier,
+                                            )
+                                            .logoutWithKakao();
+                                  } else if (loginType == 'apple') {
+                                    success =
+                                        await ref
+                                            .read(
+                                              auth2
+                                                  .authViewModelProvider
+                                                  .notifier,
+                                            )
+                                            .logoutWithApple();
+                                  }
+
+                                  if (success && context.mounted) {
+                                    await AnalyticsHelper.logEvent('로그아웃_성공', {
+                                      '로그인_방식': loginType ?? '알수없음',
+                                      '화면_이름': '로그아웃_모달',
+                                    });
+                                    context.go('/social_login');
+                                  } else {
+                                    await AnalyticsHelper.logEvent('로그아웃_실패', {
+                                      '에러': '로그아웃_실패_또는_컨텍스트_언마운트됨',
+                                      '화면_이름': '로그아웃_모달',
+                                    });
+                                    Navigator.pop(context);
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      const SnackBar(
+                                        content: Text('로그아웃에 실패했습니다.'),
+                                      ),
+                                    );
+                                  }
+                                } catch (e) {
+                                  await AnalyticsHelper.logEvent('로그아웃_실패', {
+                                    '에러': e.toString(),
+                                    '화면_이름': '로그아웃_모달',
+                                  });
+                                  Navigator.pop(context);
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    const SnackBar(
+                                      content: Text('로그아웃 중 오류가 발생했습니다.'),
+                                    ),
+                                  );
+                                }
+                              },
+                            ),
+                          ),
+                        ],
                       ),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
-              ],
+              ),
             ),
           ),
         ),

--- a/lib/presentation/setting/widgets/remove_accont_modal.dart
+++ b/lib/presentation/setting/widgets/remove_accont_modal.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mongbi_app/core/responsive_layout.dart';
 import 'package:mongbi_app/presentation/common/button_type.dart';
 import 'package:mongbi_app/presentation/common/custom_snack_bar.dart';
 import 'package:mongbi_app/presentation/common/filled_button_widget.dart';
@@ -16,85 +17,94 @@ class RemoveAccontModal extends ConsumerWidget {
 
     return DefaultTextStyle(
       style: TextStyle(),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 24),
-        child: Container(
-          width: double.infinity,
-          alignment: Alignment.center,
-          child: Container(
-            padding: EdgeInsets.only(top: 32, bottom: 16),
-            width: double.infinity,
-            decoration: BoxDecoration(
-              color: Colors.white,
-              borderRadius: BorderRadius.circular(24),
-            ),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  '정말 몽비를 탈퇴 하시겠어요?',
-                  style: TextStyle(
-                    fontFamily: 'NanumSquareRound',
-                    fontWeight: FontWeight.w800,
-                    fontSize: 18,
-                    height: 24 / 18,
-                    color: Color(0xff1A181B),
-                  ),
-                  textAlign: TextAlign.center,
+      child: Center(
+        child: SizedBox(
+          width: ResponsiveLayout.getWidth(context),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            child: Container(
+              width: double.infinity,
+              alignment: Alignment.center,
+              child: Container(
+                padding: EdgeInsets.only(top: 32, bottom: 16),
+                width: double.infinity,
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(24),
                 ),
-                SizedBox(height: 4),
-                Text(
-                  '탈퇴 후 30일간 회원가입이 불가합니다.',
-                  style: TextStyle(
-                    fontFamily: 'NanumSquareRound',
-                    fontWeight: FontWeight.w700,
-                    fontSize: 12,
-                    height: 16 / 12,
-                    color: Color(0xFF76717A),
-                  ),
-                  textAlign: TextAlign.center,
-                ),
-                SizedBox(height: 16),
-                Padding(
-                  padding: const EdgeInsets.symmetric(
-                    vertical: 8,
-                    horizontal: 24,
-                  ),
-                  child: Row(
-                    children: [
-                      Expanded(
-                        child: GhostButtonWidget(
-                          type: ButtonType.primary,
-                          text: '탈퇴하기',
-                          onPress: () async {
-                            final isRemoved = await user.removeAccount();
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      '정말 몽비를 탈퇴 하시겠어요?',
+                      style: TextStyle(
+                        fontFamily: 'NanumSquareRound',
+                        fontWeight: FontWeight.w800,
+                        fontSize: 18,
+                        height: 24 / 18,
+                        color: Color(0xff1A181B),
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                    SizedBox(height: 4),
+                    Text(
+                      '탈퇴 후 30일간 회원가입이 불가합니다.',
+                      style: TextStyle(
+                        fontFamily: 'NanumSquareRound',
+                        fontWeight: FontWeight.w700,
+                        fontSize: 12,
+                        height: 16 / 12,
+                        color: Color(0xFF76717A),
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                    SizedBox(height: 16),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(
+                        vertical: 8,
+                        horizontal: 24,
+                      ),
+                      child: Row(
+                        children: [
+                          Expanded(
+                            child: GhostButtonWidget(
+                              type: ButtonType.primary,
+                              text: '탈퇴하기',
+                              onPress: () async {
+                                final isRemoved = await user.removeAccount();
 
-                            if (context.mounted) {
-                              if (isRemoved) {
-                                context.go('/social_login');
-                              } else {
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  customSnackBar('오류로 인해 탈퇴가 중지 되었습니다', 40, 2),
-                                );
-                              }
-                            }
-                          },
-                        ),
+                                if (context.mounted) {
+                                  if (isRemoved) {
+                                    context.go('/social_login');
+                                  } else {
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      customSnackBar(
+                                        '오류로 인해 탈퇴가 중지 되었습니다',
+                                        40,
+                                        2,
+                                      ),
+                                    );
+                                  }
+                                }
+                              },
+                            ),
+                          ),
+                          SizedBox(width: 8),
+                          Expanded(
+                            child: FilledButtonWidget(
+                              type: ButtonType.primary,
+                              text: '아니오',
+                              onPress: () {
+                                context.pop();
+                              },
+                            ),
+                          ),
+                        ],
                       ),
-                      SizedBox(width: 8),
-                      Expanded(
-                        child: FilledButtonWidget(
-                          type: ButtonType.primary,
-                          text: '아니오',
-                          onPress: () {
-                            context.pop();
-                          },
-                        ),
-                      ),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
-              ],
+              ),
             ),
           ),
         ),

--- a/lib/presentation/setting/widgets/setting_user_info_header.dart
+++ b/lib/presentation/setting/widgets/setting_user_info_header.dart
@@ -16,30 +16,33 @@ class UserInfoHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      behavior: HitTestBehavior.translucent,
-      onTap: onTap,
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.end,
-        children: [
-          Text(
-            '$nickname 님',
-            style: Font.title20.copyWith(color: Color(0xFF6321B5)),
-          ),
-          SizedBox(width: 8),
-          Text(
-            '$loginType 로그인',
-            style: Font.subTitle12.copyWith(color: Color(0xFFCA9FFF)),
-          ),
-          Spacer(),
-          SvgPicture.asset(
-            'assets/icons/chevron-right.svg',
-            width: 24,
-            height: 24,
-            colorFilter: ColorFilter.mode(Color(0xFFA6A1AA), BlendMode.srcIn),
-          ),
-          SizedBox(width: 20),
-        ],
+    return Padding(
+      padding: const EdgeInsets.only(top: 16),
+      child: GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onTap: onTap,
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            Text(
+              '$nickname 님',
+              style: Font.title20.copyWith(color: Color(0xFF6321B5)),
+            ),
+            SizedBox(width: 8),
+            Text(
+              '$loginType 로그인',
+              style: Font.subTitle12.copyWith(color: Color(0xFFCA9FFF)),
+            ),
+            Spacer(),
+            SvgPicture.asset(
+              'assets/icons/chevron-right.svg',
+              width: 24,
+              height: 24,
+              colorFilter: ColorFilter.mode(Color(0xFFA6A1AA), BlendMode.srcIn),
+            ),
+            SizedBox(width: 20),
+          ],
+        ),
       ),
     );
   }

--- a/lib/presentation/statistics/statistics_page.dart
+++ b/lib/presentation/statistics/statistics_page.dart
@@ -47,6 +47,8 @@ class _StatisticsPageState extends ConsumerState<StatisticsPage>
     final statisticsAsync = ref.watch(statisticsViewModelProvider);
 
     return SafeArea(
+      left: false,
+      right: false,
       child: Stack(
         children: [
           NestedScrollView(

--- a/lib/presentation/statistics/widgets/month_statistics.dart
+++ b/lib/presentation/statistics/widgets/month_statistics.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:mongbi_app/core/get_widget_info.dart';
 import 'package:mongbi_app/data/dtos/statistics_dto.dart';
 import 'package:mongbi_app/presentation/statistics/statistics_key/statistics_key.dart';
 import 'package:mongbi_app/presentation/statistics/widgets/dream_frequency_card.dart';
@@ -24,23 +23,7 @@ class MonthStatistics extends ConsumerStatefulWidget {
 class _MonthStatisticsState extends ConsumerState<MonthStatistics>
     with RouteAware {
   bool isMonth = true;
-  double? monthPickerButtonPosition;
   final ScrollController scrollController = ScrollController();
-
-  @override
-  void initState() {
-    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-      final monthPickerButtonInfo = getWidgetInfo(monthPickerButton);
-      final monthButtonPosition =
-          monthPickerButtonInfo!.localToGlobal(Offset.zero).dy;
-      final monthButtonHeight = monthPickerButtonInfo.size.height;
-      setState(() {
-        monthPickerButtonPosition = monthButtonPosition + monthButtonHeight;
-      });
-    });
-
-    super.initState();
-  }
 
   @override
   void dispose() {
@@ -60,98 +43,88 @@ class _MonthStatisticsState extends ConsumerState<MonthStatistics>
         bottom: 95,
       ),
       children: [
-        Stack(
+        Column(
           children: [
-            Column(
-              children: [
-                MonthYearPickerButton(
-                  isMonth: isMonth,
-                  scrollController: scrollController,
-                  pickerButtonPosition: monthPickerButtonPosition ?? 0,
-                  horizontalPadding: widget.horizontalPadding,
-                ),
+            MonthYearPickerButton(
+              isMonth: isMonth,
+              scrollController: scrollController,
+              horizontalPadding: widget.horizontalPadding,
+            ),
 
-                MonthYearPicker(
-                  key: isMonth ? monthPickerKey : yearPickerKey,
-                  isMonth: isMonth,
-                  scrollController: scrollController,
-                  left: widget.horizontalPadding,
-                  top: monthPickerButtonPosition ?? 0,
-                ),
+            MonthYearPicker(
+              key: isMonth ? monthPickerKey : yearPickerKey,
+              isMonth: isMonth,
+              scrollController: scrollController,
+            ),
 
-                statisticsAsync.when(
-                  loading: () {
-                    return SizedBox();
-                  },
-                  data: (data) {
-                    final monthStatistics = data?.month;
-                    final now = DateTime.now();
-                    final yearMonth =
-                        monthStatistics?.month?.split('-') ??
-                        [
-                          pickerState.focusedMonth.year.toString(),
-                          pickerState.focusedMonth.month.toString(),
-                        ]; // "2025-06"
-                    final frequency = monthStatistics?.frequency ?? 0;
-                    final challengeSuccessRate =
-                        monthStatistics?.challengeSuccessRate ?? 0;
-                    final totalDays = monthStatistics?.totalDays ?? 0;
-                    final distribution =
-                        monthStatistics?.distribution ?? DreamScore();
-                    final moodState = monthStatistics?.moodState;
-                    final keywordList = monthStatistics?.keywords;
-                    final isFirst = frequency == 0;
-                    final isCurrent =
-                        now.year == int.parse(yearMonth[0]) &&
-                        now.month == int.parse(yearMonth[1]);
+            statisticsAsync.when(
+              loading: () {
+                return SizedBox();
+              },
+              data: (data) {
+                final monthStatistics = data?.month;
+                final now = DateTime.now();
+                final yearMonth =
+                    monthStatistics?.month?.split('-') ??
+                    [
+                      pickerState.focusedMonth.year.toString(),
+                      pickerState.focusedMonth.month.toString(),
+                    ]; // "2025-06"
+                final frequency = monthStatistics?.frequency ?? 0;
+                final challengeSuccessRate =
+                    monthStatistics?.challengeSuccessRate ?? 0;
+                final totalDays = monthStatistics?.totalDays ?? 0;
+                final distribution =
+                    monthStatistics?.distribution ?? DreamScore();
+                final moodState = monthStatistics?.moodState;
+                final keywordList = monthStatistics?.keywords;
+                final isFirst = frequency == 0;
+                final isCurrent =
+                    now.year == int.parse(yearMonth[0]) &&
+                    now.month == int.parse(yearMonth[1]);
 
-                    WidgetsBinding.instance.addPostFrameCallback((_) {
-                      if (isFirst && isCurrent) {
-                        ref.read(snackBarStatusProvider.notifier).state = true;
-                      } else {
-                        ref.read(snackBarStatusProvider.notifier).state = false;
-                      }
-                    });
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  if (isFirst && isCurrent) {
+                    ref.read(snackBarStatusProvider.notifier).state = true;
+                  } else {
+                    ref.read(snackBarStatusProvider.notifier).state = false;
+                  }
+                });
 
-                    return Column(
-                      children: [
-                        Padding(
-                          padding: EdgeInsets.only(top: 16),
-                          child: Row(
-                            children: [
-                              DreamFrequencyCard(
-                                isFirst: isFirst,
-                                frequency: frequency,
-                                totalDays: totalDays,
-                              ),
-                              SizedBox(width: 16),
-                              GiftFrequencyCard(
-                                isFirst: isFirst,
-                                challengeSuccessRate: challengeSuccessRate,
-                              ),
-                            ],
+                return Column(
+                  children: [
+                    Padding(
+                      padding: EdgeInsets.only(top: 16),
+                      child: Row(
+                        children: [
+                          DreamFrequencyCard(
+                            isFirst: isFirst,
+                            frequency: frequency,
+                            totalDays: totalDays,
                           ),
-                        ),
-                        DreamMoodDistribution(
-                          isFirst: isFirst,
-                          distribution: distribution,
-                        ),
-                        DreamTypeMoodState(
-                          isMonth: isMonth,
-                          moodState: moodState,
-                        ),
-                        PsychologyKeywordChart(
-                          isFirst: isFirst,
-                          keywordList: keywordList ?? [],
-                        ),
-                      ],
-                    );
-                  },
-                  error: (error, stackTrace) {
-                    return Center(child: Text('예기치 못한 오류가 발생했다몽'));
-                  },
-                ),
-              ],
+                          SizedBox(width: 16),
+                          GiftFrequencyCard(
+                            isFirst: isFirst,
+                            challengeSuccessRate: challengeSuccessRate,
+                          ),
+                        ],
+                      ),
+                    ),
+                    DreamMoodDistribution(
+                      isFirst: isFirst,
+                      distribution: distribution,
+                    ),
+                    DreamTypeMoodState(isMonth: isMonth, moodState: moodState),
+                    PsychologyKeywordChart(
+                      isFirst: isFirst,
+                      keywordList: keywordList ?? [],
+                    ),
+                  ],
+                );
+              },
+              error: (error, stackTrace) {
+                return Center(child: Text('예기치 못한 오류가 발생했다몽'));
+              },
             ),
           ],
         ),

--- a/lib/presentation/statistics/widgets/month_year_picker.dart
+++ b/lib/presentation/statistics/widgets/month_year_picker.dart
@@ -1,19 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mongbi_app/core/get_widget_info.dart';
+import 'package:mongbi_app/presentation/statistics/statistics_key/statistics_key.dart';
 import 'package:mongbi_app/providers/statistics_provider.dart';
 
 class MonthYearPicker extends ConsumerStatefulWidget {
   const MonthYearPicker({
     super.key,
     required this.isMonth,
-    required this.left,
-    required this.top,
     required this.scrollController,
   });
 
   final bool isMonth;
-  final double left;
-  final double top;
   final ScrollController scrollController;
 
   @override
@@ -32,6 +30,12 @@ class MonthYearPickerState extends ConsumerState<MonthYearPicker> {
   void show() {
     if (_overlayEntry != null) return; // 이미 띄워져 있으면 무시
 
+    final buttonKey = widget.isMonth ? monthPickerButton : yearPickerButton;
+    final pickerButtonInfo = getWidgetInfo(buttonKey);
+    final positionX = pickerButtonInfo!.localToGlobal(Offset.zero).dx;
+    final positionY = pickerButtonInfo.localToGlobal(Offset.zero).dy;
+    final buttonHeight = pickerButtonInfo.size.height;
+
     _overlayEntry = OverlayEntry(
       builder:
           (context) => DefaultTextStyle(
@@ -46,8 +50,8 @@ class MonthYearPickerState extends ConsumerState<MonthYearPicker> {
                   child: Container(color: Colors.transparent),
                 ),
                 Positioned(
-                  left: widget.left,
-                  top: widget.top,
+                  left: positionX,
+                  top: positionY + buttonHeight,
                   child: Container(
                     padding: const EdgeInsets.only(right: 12),
                     width: 100,

--- a/lib/presentation/statistics/widgets/month_year_picker_button.dart
+++ b/lib/presentation/statistics/widgets/month_year_picker_button.dart
@@ -11,13 +11,11 @@ class MonthYearPickerButton extends ConsumerWidget {
     super.key,
     required this.isMonth,
     required this.scrollController,
-    required this.pickerButtonPosition,
     required this.horizontalPadding,
   });
 
   final bool isMonth;
   final ScrollController scrollController;
-  final double pickerButtonPosition;
   final double horizontalPadding;
 
   @override

--- a/lib/presentation/statistics/widgets/mood_state_info_modal.dart
+++ b/lib/presentation/statistics/widgets/mood_state_info_modal.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:mongbi_app/core/font.dart';
+import 'package:mongbi_app/core/responsive_layout.dart';
 
 class MoodStateInfoModal {
   OverlayEntry? _overlayEntry;
@@ -39,95 +40,104 @@ class MoodStateInfoModal {
                   },
                   child: Container(color: Color(0xB2000000)),
                 ),
-                Container(
-                  alignment: Alignment.center,
-                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                Center(
                   child: Container(
-                    padding: EdgeInsets.symmetric(vertical: 24, horizontal: 20),
-                    decoration: BoxDecoration(
-                      color: Color(0xFFFAFAFA),
-                      borderRadius: BorderRadius.circular(16),
-                    ),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            Text('꿈 유형별 기분 상태', style: Font.title14),
-                            GestureDetector(
-                              onTap: () {
-                                hide();
-                              },
-                              child: SvgPicture.asset(
-                                'assets/icons/cancel.svg',
-                                fit: BoxFit.cover,
-                                width: 20,
+                    width: ResponsiveLayout.getWidth(context),
+                    alignment: Alignment.center,
+                    padding: const EdgeInsets.symmetric(horizontal: 24),
+                    child: Container(
+                      padding: EdgeInsets.symmetric(
+                        vertical: 24,
+                        horizontal: 20,
+                      ),
+                      decoration: BoxDecoration(
+                        color: Color(0xFFFAFAFA),
+                        borderRadius: BorderRadius.circular(16),
+                      ),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              Text('꿈 유형별 기분 상태', style: Font.title14),
+                              GestureDetector(
+                                onTap: () {
+                                  hide();
+                                },
+                                child: SvgPicture.asset(
+                                  'assets/icons/cancel.svg',
+                                  fit: BoxFit.cover,
+                                  width: 20,
+                                ),
                               ),
+                            ],
+                          ),
+                          SizedBox(height: 8),
+                          _descriptionWidget(
+                            context: context,
+                            label: '행',
+                            content: '꿈 유형 (길몽, 일상몽, 악몽)',
+                          ),
+                          SizedBox(height: 16),
+                          _descriptionWidget(
+                            context: context,
+                            label: '열',
+                            content: '기분상태 (기분 이모티콘의 색상으로 표현함)',
+                          ),
+                          SizedBox(height: 6),
+                          Padding(
+                            padding: EdgeInsets.symmetric(horizontal: 18),
+                            child: Row(
+                              children: [
+                                ...List.generate(iconPathList.length, (index) {
+                                  bool isLast =
+                                      iconPathList.length == index + 1;
+
+                                  return Container(
+                                    padding:
+                                        isLast
+                                            ? null
+                                            : EdgeInsets.only(right: 4),
+                                    child: SvgPicture.asset(
+                                      iconPathList[index],
+                                      fit: BoxFit.cover,
+                                      width: 20,
+                                    ),
+                                  );
+                                }),
+                              ],
                             ),
-                          ],
-                        ),
-                        SizedBox(height: 8),
-                        _descriptionWidget(
-                          context: context,
-                          label: '행',
-                          content: '꿈 유형 (길몽, 일상몽, 악몽)',
-                        ),
-                        SizedBox(height: 16),
-                        _descriptionWidget(
-                          context: context,
-                          label: '열',
-                          content: '기분상태 (기분 이모티콘의 색상으로 표현함)',
-                        ),
-                        SizedBox(height: 6),
-                        Padding(
-                          padding: EdgeInsets.symmetric(horizontal: 18),
-                          child: Row(
-                            children: [
-                              ...List.generate(iconPathList.length, (index) {
-                                bool isLast = iconPathList.length == index + 1;
-
-                                return Container(
-                                  padding:
-                                      isLast ? null : EdgeInsets.only(right: 4),
-                                  child: SvgPicture.asset(
-                                    iconPathList[index],
-                                    fit: BoxFit.cover,
-                                    width: 20,
-                                  ),
-                                );
-                              }),
-                            ],
                           ),
-                        ),
-                        SizedBox(height: 16),
-                        _descriptionWidget(
-                          context: context,
-                          label: '칸',
-                          content: '기분 상태 빈도 (짙을수록 많이 해당됨)',
-                        ),
-                        SizedBox(height: 6),
-                        Padding(
-                          padding: EdgeInsets.only(left: 18),
-                          child: Row(
-                            children: [
-                              ...List.generate(5, (index) {
-                                bool isList = 5 == index + 1;
-
-                                return _frequencyWidget(
-                                  context: context,
-                                  text:
-                                      isMonth
-                                          ? monthFrequencyList[index]
-                                          : yearFrequencyList[index],
-                                  color: colorList[index],
-                                  isLast: isList,
-                                );
-                              }),
-                            ],
+                          SizedBox(height: 16),
+                          _descriptionWidget(
+                            context: context,
+                            label: '칸',
+                            content: '기분 상태 빈도 (짙을수록 많이 해당됨)',
                           ),
-                        ),
-                      ],
+                          SizedBox(height: 6),
+                          Padding(
+                            padding: EdgeInsets.only(left: 18),
+                            child: Row(
+                              children: [
+                                ...List.generate(5, (index) {
+                                  bool isList = 5 == index + 1;
+
+                                  return _frequencyWidget(
+                                    context: context,
+                                    text:
+                                        isMonth
+                                            ? monthFrequencyList[index]
+                                            : yearFrequencyList[index],
+                                    color: colorList[index],
+                                    isLast: isList,
+                                  );
+                                }),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                 ),

--- a/lib/presentation/statistics/widgets/year_statistics.dart
+++ b/lib/presentation/statistics/widgets/year_statistics.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:mongbi_app/core/get_widget_info.dart';
 import 'package:mongbi_app/data/dtos/statistics_dto.dart';
 import 'package:mongbi_app/presentation/statistics/statistics_key/statistics_key.dart';
 import 'package:mongbi_app/presentation/statistics/widgets/dream_frequency_card.dart';
@@ -24,23 +23,7 @@ class YearStatistics extends ConsumerStatefulWidget {
 class _YearStatisticsState extends ConsumerState<YearStatistics>
     with RouteAware {
   bool isMonth = false;
-  double? yearPickerButtonPosition;
   final ScrollController scrollController = ScrollController();
-
-  @override
-  void initState() {
-    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-      final yearPickerButtonInfo = getWidgetInfo(yearPickerButton);
-      final yearButtonPosition =
-          yearPickerButtonInfo!.localToGlobal(Offset.zero).dy;
-      final yearButtonHeight = yearPickerButtonInfo.size.height;
-      setState(() {
-        yearPickerButtonPosition = yearButtonPosition + yearButtonHeight;
-      });
-    });
-
-    super.initState();
-  }
 
   @override
   void dispose() {
@@ -65,7 +48,6 @@ class _YearStatisticsState extends ConsumerState<YearStatistics>
             MonthYearPickerButton(
               isMonth: isMonth,
               scrollController: scrollController,
-              pickerButtonPosition: yearPickerButtonPosition ?? 0,
               horizontalPadding: widget.horizontalPadding,
             ),
 
@@ -73,8 +55,6 @@ class _YearStatisticsState extends ConsumerState<YearStatistics>
               key: isMonth ? monthPickerKey : yearPickerKey,
               isMonth: isMonth,
               scrollController: scrollController,
-              top: yearPickerButtonPosition ?? 0,
-              left: widget.horizontalPadding,
             ),
 
             statisticsAsync.when(

--- a/lib/presentation/terms/widgets/terms_bottom_sheet_layout_widget.dart
+++ b/lib/presentation/terms/widgets/terms_bottom_sheet_layout_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mongbi_app/core/responsive_layout.dart';
 import 'package:mongbi_app/core/secure_storage_service.dart';
 import 'package:mongbi_app/data/dtos/terms_aggrement_dto.dart';
 import 'package:mongbi_app/domain/entities/terms.dart';
@@ -82,6 +83,7 @@ class _TermsBottomSheetState extends ConsumerState<TermsBottomSheet> {
     final isEssentialChecked = mandatoryIndexes.every((i) => isCheckedList[i]);
 
     return Container(
+      width: ResponsiveLayout.getWidth(context),
       padding: EdgeInsets.only(
         top: 24,
         left: 24,

--- a/lib/presentation/terms/widgets/terms_checkbox_widget.dart
+++ b/lib/presentation/terms/widgets/terms_checkbox_widget.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:mongbi_app/core/font.dart';
-import 'package:mongbi_app/core/get_responsive_ratio_by_width.dart';
 import 'package:mongbi_app/domain/entities/terms.dart';
 import 'package:mongbi_app/presentation/terms/terms_inner_page.dart';
 import 'package:mongbi_app/presentation/terms/widgets/terms_custom_checkbox.widget.dart';
@@ -51,17 +50,9 @@ class TermsAgreementTile extends StatelessWidget {
                       style:
                           isAllAgree
                               ? Font.title16.copyWith(
-                                fontSize: getResponsiveRatioByWidth(
-                                  context,
-                                  16,
-                                ),
                                 color: const Color(0xFF1A181B),
                               )
                               : Font.body16.copyWith(
-                                fontSize: getResponsiveRatioByWidth(
-                                  context,
-                                  16,
-                                ),
                                 color: const Color(0xFF1A181B),
                               ),
                     ),

--- a/lib/presentation/terms/widgets/terms_text_widget.dart
+++ b/lib/presentation/terms/widgets/terms_text_widget.dart
@@ -12,10 +12,7 @@ class TermsHeaderText extends StatelessWidget {
       children: [
         Text(
           '몽비 이용을 위한\n이용약관 동의가 필요해몽',
-          style: Font.title18.copyWith(
-            fontSize: getResponsiveRatioByWidth(context, 18),
-            color: Colors.black,
-          ),
+          style: Font.title18.copyWith(color: Colors.black),
         ),
       ],
     );


### PR DESCRIPTION
### 🚀 개요
반응형 UI

### 🔧 작업 내용
- 기기가 480이상일 때 페이지 자체를 가운데 정렬해서 반응형 대응
  - 바텀네비게이션바에 연결된 페이지는 ResponsiveLayout 위젯 사용
  - 그렇지 않은 페이지(모달, 자체적으로 Scaffold가 있는 페이지)는 ResponsiveLayout.getWidth 정적메서드 사용


### 💡 Issue
Closes #341

### 👍 리뷰 요구사항
- 코드리뷰 하기 전에 지금 PR의 원격 브랜치로 이동해서 먼저 다들 사용하던 기기(테스트기기든 실물기기든)에서 잘 나오는지, 그리고 아이패드나 태블릿에서도 잘 되는지 각자 페이지를 확인해주세요.
- 홈에서 몽비 아이콘 사이즈를 반응형 대응하게 변경해야 합니다
- 챌린지 선택하는 화면에서 챌린지UI 위치값을 반응형 대응하게 해야합니다.
- 혹시 바텀네비게이션바의 아이콘이 작으면 수정해야 합니다.
- 마이페이지에서 앱바와 타이틀 사이의 여백이 디자인과 달라서 변경했습니다.
