### PR TITLE
[Core] 배경음악 재생시 이미 dispose가 되었는데 ref 사용으로 인한 강제종료

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,7 +17,6 @@ void main() async {
   await dotenv.load(fileName: '.env');
   // 캘린더 한글화
   await initializeDateFormatting();
-  
 
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
   KakaoSdk.init(
@@ -59,7 +58,9 @@ class _MyAppState extends ConsumerState<MyApp> with WidgetsBindingObserver {
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
-    ref.read(backgroundMusicProvider).dispose();
+    if (mounted) {
+      ref.read(backgroundMusicProvider).dispose();
+    }
     super.dispose();
   }
 


### PR DESCRIPTION
### 🚀 개요
dispose() 메서드에서 ref.read()를 사용할 때 "Cannot use 'ref' after the widget was disposed" 오류가 발생하여 앱이 강제종료

### 🔧 작업 내용
- mounted로 확인하여 배경음악 dispose

### 💡 Issue
Closes #346 
