### PR TITLE
[Challenge] UT 피드백 반영 - UI 및 기능 수정

### DIFF
--- a/lib/presentation/challenge/challenge_page.dart
+++ b/lib/presentation/challenge/challenge_page.dart
@@ -144,7 +144,8 @@ class ChallengePage extends ConsumerWidget {
                           context: context,
                           builder:
                               (context) => MongbiDialog(
-                                content: '아앗, 아쉬워라\n꿈 잘먹었몽! 오늘도 힘내라몽',
+                                title: '홈으로 돌아갈래몽?',
+                                content: '선물을 선택하지 않아도,\n오늘 꿈은 더 이상 먹지 못해!',
                                 buttonText: '고마워',
                                 onSubmit: () {
                                   context.go('/home');
@@ -183,7 +184,8 @@ class ChallengePage extends ConsumerWidget {
                           context: context,
                           builder:
                               (context) => MongbiDialog(
-                                content: '꿈 잘먹었몽!\n선물 완료하고, 오늘도 힘내라몽',
+                                title: '꿈 잘먹었어몽!',
+                                content: '선물을 완료해서\n더 행복한 하루 보내자!',
                                 buttonText: '고마워',
                                 onSubmit: () async {
                                   await ref

--- a/lib/presentation/challenge/challenge_page.dart
+++ b/lib/presentation/challenge/challenge_page.dart
@@ -19,8 +19,8 @@ class ChallengePage extends ConsumerWidget {
     final selectedIndex =
         ref.watch(challengeViewModelProvider.notifier).selectedChallengeIndex;
 
-    final screenWidth = MediaQuery.of(context).size.width;
-    final screenHeight = MediaQuery.of(context).size.height;
+    final screenWidth = MediaQuery.sizeOf(context).width;
+    final screenHeight = MediaQuery.sizeOf(context).height;
 
     return Scaffold(
       backgroundColor: const Color(0xFFFAFAFA),

--- a/lib/presentation/challenge/challenge_page.dart
+++ b/lib/presentation/challenge/challenge_page.dart
@@ -19,6 +19,9 @@ class ChallengePage extends ConsumerWidget {
     final selectedIndex =
         ref.watch(challengeViewModelProvider.notifier).selectedChallengeIndex;
 
+    final screenWidth = MediaQuery.of(context).size.width;
+    final screenHeight = MediaQuery.of(context).size.height;
+
     return Scaffold(
       backgroundColor: const Color(0xFFFAFAFA),
       body: SafeArea(
@@ -50,8 +53,8 @@ class ChallengePage extends ConsumerWidget {
                             children: [
                               if (challenges.length >= 3) ...[
                                 Positioned(
-                                  top: 44,
-                                  left: 0,
+                                  top: screenHeight * 0.05,
+                                  left: screenWidth * 0.0,
                                   child: GestureDetector(
                                     onTap: () {
                                       ref
@@ -75,8 +78,8 @@ class ChallengePage extends ConsumerWidget {
                                   ),
                                 ),
                                 Positioned(
-                                  top: 220,
-                                  right: 10,
+                                  top: screenHeight * 0.27,
+                                  right: screenWidth * 0.03,
                                   child: GestureDetector(
                                     onTap: () {
                                       ref
@@ -100,8 +103,8 @@ class ChallengePage extends ConsumerWidget {
                                   ),
                                 ),
                                 Positioned(
-                                  top: 410,
-                                  left: 10,
+                                  top: screenHeight * 0.5,
+                                  left: screenWidth * 0.03,
                                   child: GestureDetector(
                                     onTap: () {
                                       ref

--- a/lib/presentation/challenge/widgets/challenge_container.dart
+++ b/lib/presentation/challenge/widgets/challenge_container.dart
@@ -26,8 +26,7 @@ class ChallengeContainer extends StatelessWidget {
       duration: const Duration(milliseconds: 300),
       curve: Curves.easeInOut,
       child: AnimatedRotation(
-        turns:
-            (isSelected ? 0.0 : rotationAngle),
+        turns: (isSelected ? 0.0 : rotationAngle) / (2 * 3.14159),
         duration: Duration(milliseconds: 300),
         curve: Curves.easeInOut,
         child: Container(

--- a/lib/presentation/challenge/widgets/challenge_container.dart
+++ b/lib/presentation/challenge/widgets/challenge_container.dart
@@ -25,9 +25,11 @@ class ChallengeContainer extends StatelessWidget {
       scale: isSelected ? 1.1 : 1.0,
       duration: const Duration(milliseconds: 300),
       curve: Curves.easeInOut,
-      child: Transform(
-        alignment: Alignment.center,
-        transform: Matrix4.identity()..rotateZ(rotationAngle),
+      child: AnimatedRotation(
+        turns:
+            (isSelected ? 0.0 : rotationAngle),
+        duration: Duration(milliseconds: 300),
+        curve: Curves.easeInOut,
         child: Container(
           width: screenHeight * 0.23,
           height: screenHeight * 0.23,

--- a/lib/presentation/challenge/widgets/challenge_intro_mongbi_message_view.dart
+++ b/lib/presentation/challenge/widgets/challenge_intro_mongbi_message_view.dart
@@ -12,9 +12,15 @@ class MongbiMessageView extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
         Text(
-          '선물을 준비했몽, 골라봐!\n따라하면 기분이 좋아질거야!',
+          '선물을 준비했몽, 골라봐!',
           style: Font.title20.copyWith(color: Color(0xFF1A181B)),
           textAlign: TextAlign.center,
+        ),
+        SizedBox(height: 8),
+        Text(
+          '감정에 어울리는 작은 챌린지를 통해,\n하루를 기분 좋게 시작할 수 있어요.',
+          textAlign: TextAlign.center,
+          style: Font.body16.copyWith(color: Color(0xFF636363)),
         ),
         SizedBox(height: 48),
         FloatingAnimationWidget(child: MongbiCharacter(size: 288)),

--- a/lib/presentation/challenge/widgets/mongbi_dialog.dart
+++ b/lib/presentation/challenge/widgets/mongbi_dialog.dart
@@ -7,11 +7,13 @@ import 'package:mongbi_app/presentation/dream/widgets/custom_button.dart';
 class MongbiDialog extends StatelessWidget {
   const MongbiDialog({
     super.key,
+    required this.title,
     required this.content,
     required this.buttonText,
     required this.onSubmit,
   });
 
+  final String title;
   final String content;
   final String buttonText;
   final VoidCallback onSubmit;
@@ -33,8 +35,14 @@ class MongbiDialog extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: [
               Text(
-                content,
+                title,
                 style: Font.title18.copyWith(color: Color(0xFF1A181B)),
+                textAlign: TextAlign.center,
+              ),
+              SizedBox(height: 2),
+              Text(
+                content,
+                style: Font.subTitle12.copyWith(color: Color(0xFF76717A)),
                 textAlign: TextAlign.center,
               ),
               MongbiCharacter(size: 144),


### PR DESCRIPTION
### 🚀 개요
- 챌린지를 선택하는 각 화면에 안내 메세지 추가
- 챌린지 선택 화면에서 흠.. 안할래 버튼을 클릭하면 홈 화면으로 이동한다는 안내가 담긴 Dialog 표시
- 태블릿 / 아이패드에서 챌린지 포지션 수정

### 🔧 작업 내용
- 챌린지 설명 추가
- Dialog 공용 위젯에 제목과 내용을 넣을 수 있도록 수정
- 챌린지를 선택하면 기울어져 있는 챌린지 컨테이너가 올바르게 볼 수 있도록 회전
- 화면 크기(태블릿 / 아이패드)에 따라 태블릿 위치 조정

### 💡 Issue
Closes #298
