### PR TITLE
[History] RemoteHistoryDataSource에서 SecureStorageService 직접 호출을 Provider 사용으로 교체

### DIFF
--- a/lib/data/data_sources/remote_history_data_source.dart
+++ b/lib/data/data_sources/remote_history_data_source.dart
@@ -5,14 +5,15 @@ import 'package:mongbi_app/data/dtos/history_dto.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 class RemoteHistoryDataSource implements HistoryDataSource {
-  RemoteHistoryDataSource(this._dio);
+  RemoteHistoryDataSource(this._dio, this._secureStorageService);
 
   final Dio _dio;
+  final SecureStorageService _secureStorageService;
 
   @override
   Future<List<HistoryDto>> feachUserDreamsHistory() async {
     try {
-      final userIndex = await SecureStorageService().getUserIdx();
+      final userIndex = await _secureStorageService.getUserIdx();
       final response = await _dio.get('/dreams/$userIndex');
 
       if (response.data['code'] == 201 && response.data['success']) {
@@ -21,7 +22,9 @@ class RemoteHistoryDataSource implements HistoryDataSource {
             results.map((e) => HistoryDto.fromJson(e)).toList();
         return historyDtoList;
       } else {
-        final error = Exception(response.data['message'] ?? '알 수 없는 오류가 발생하였습니다.');
+        final error = Exception(
+          response.data['message'] ?? '알 수 없는 오류가 발생하였습니다.',
+        );
         await Sentry.captureException(
           error,
           withScope: (scope) {

--- a/lib/providers/history_provider.dart
+++ b/lib/providers/history_provider.dart
@@ -12,7 +12,8 @@ import 'package:mongbi_app/providers/core_providers.dart';
 
 final _historyDataSourceProvider = Provider<HistoryDataSource>((ref) {
   final dio = ref.read(dioProvider);
-  return RemoteHistoryDataSource(dio);
+  final secureStorageService = ref.read(secureStorageServiceProvider);
+  return RemoteHistoryDataSource(dio, secureStorageService);
 });
 
 final _historyRepositoryProvider = Provider<HistoryRepository>((ref) {


### PR DESCRIPTION
### 🚀 개요
RemoteHistoryDataSource에서 SecureStorageService 직접 호출을 Provider 사용으로 교체

### 💡 Issue
Closes #373 