### PR TITLE
[Refactor] ViewModel에서 SecureStorageService 직접 접근 제거

### DIFF
--- a/lib/presentation/auth/viewmodels/auth_view_model.dart
+++ b/lib/presentation/auth/viewmodels/auth_view_model.dart
@@ -22,6 +22,7 @@ class AuthViewModel extends Notifier<User?> {
   late final LoginWithApple _loginWithApple;
   final _secureStorage = const FlutterSecureStorage();
   late final Future<SharedPreferences> _prefsFuture;
+
   @override
   User? build() {
     _loginWithNaver = ref.read(loginWithNaverUseCaseProvider);
@@ -29,11 +30,33 @@ class AuthViewModel extends Notifier<User?> {
     _loginWithApple = ref.read(loginWithAppleUseCaseProvider);
 
     _prefsFuture = SharedPreferences.getInstance();
+
+    _restoreUserFromStorage();
+
     return null;
+  }
+
+  /// 앱 시작 시 Storage에서 사용자 정보 복원
+  Future<void> _restoreUserFromStorage() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final isLogined = prefs.getBool('isLogined') ?? false;
+
+      if (isLogined) {
+        final getUserUseCase = ref.read(getUserInfoUseCaseProvider);
+        final userInfo = await getUserUseCase.execute();
+        if (userInfo.isNotEmpty) {
+          state = userInfo[0];
+        }
+      }
+    } catch (e) {
+      // 에러 발생 시 무시 (로그인 안 된 상태로 유지)
+    }
   }
 
   bool _isLoading = false;
   bool get isLoading => _isLoading;
+  int? get userId => state?.userIdx;
 
   Future<bool> loginWithApple() async {
     _isLoading = true;

--- a/lib/presentation/challenge/view_models/challenge_view_model.dart
+++ b/lib/presentation/challenge/view_models/challenge_view_model.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:mongbi_app/core/secure_storage_service.dart';
 import 'package:mongbi_app/domain/entities/challenge.dart';
+import 'package:mongbi_app/providers/auth_provider.dart';
 import 'package:mongbi_app/providers/challenge_provider.dart';
 import 'package:mongbi_app/providers/dream_provider.dart';
 
@@ -38,7 +38,7 @@ class ChallengeViewModel extends AsyncNotifier<List<Challenge>> {
     }
 
     final challengeId = challenges[selectedIndex].id;
-    final uid = await SecureStorageService().getUserIdx();
+    final uid = ref.read(authViewModelProvider.notifier).userId;
     final currentDreamId =
         ref.read(dreamInterpretationViewModelProvider).dreamId;
 

--- a/lib/presentation/dream/view_models/dream_write_view_model.dart
+++ b/lib/presentation/dream/view_models/dream_write_view_model.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:mongbi_app/core/secure_storage_service.dart';
 import 'package:mongbi_app/presentation/dream/models/dream_write_state.dart';
+import 'package:mongbi_app/providers/auth_provider.dart';
 import 'package:mongbi_app/providers/dream_provider.dart';
 
 class DreamWriteViewModel extends AutoDisposeNotifier<DreamWriteState> {
@@ -25,7 +25,7 @@ class DreamWriteViewModel extends AutoDisposeNotifier<DreamWriteState> {
   Future<void> submitDream({bool isReInterpretation = false}) async {
     if (state.dreamContent.trim().length < 10) return;
     if (state.selectedIndex == -1) return;
-    final uid = await SecureStorageService().getUserIdx();
+    final uid = ref.read(authViewModelProvider.notifier).userId;
     if (uid == null) return;
 
     final dream = await ref

--- a/lib/presentation/home/view_models/home_view_model.dart
+++ b/lib/presentation/home/view_models/home_view_model.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:mongbi_app/core/secure_storage_service.dart';
 import 'package:mongbi_app/presentation/home/models/home_state.dart';
+import 'package:mongbi_app/providers/auth_provider.dart';
 import 'package:mongbi_app/providers/challenge_provider.dart';
 
 class HomeViewModel extends AutoDisposeNotifier<HomeState> {
@@ -11,7 +11,7 @@ class HomeViewModel extends AutoDisposeNotifier<HomeState> {
 
   Future<void> fetchActiveChallenge() async {
     state = state.copyWith(isLoading: true, error: null);
-    final uid = await SecureStorageService().getUserIdx();
+    final uid = ref.read(authViewModelProvider.notifier).userId;
 
     if (uid == null) {
       return;
@@ -33,7 +33,7 @@ class HomeViewModel extends AutoDisposeNotifier<HomeState> {
 
     state = state.copyWith(isCompleting: true);
 
-    final uid = await SecureStorageService().getUserIdx();
+    final uid = ref.read(authViewModelProvider.notifier).userId;
     final challengeId = state.challenge!.id;
     final challengeStatus = isComplete ? 'COMPLETED' : 'ABANDONED';
 

--- a/test/data/alarm_data_source_test.dart
+++ b/test/data/alarm_data_source_test.dart
@@ -1,23 +1,35 @@
 import 'dart:convert';
+
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:mongbi_app/core/secure_storage_service.dart';
 import 'package:mongbi_app/data/data_sources/alarm_data_source.dart';
 import 'package:mongbi_app/data/data_sources/remote_alarm_data_source.dart';
 import 'package:mongbi_app/data/dtos/alarm_dto.dart';
 
 class MockDio extends Mock implements Dio {}
 
+class MockSecureStorageService extends Mock implements SecureStorageService {}
+
 void main() {
   MockDio? mockDio;
+  MockSecureStorageService? mockSecureStorageService;
   AlarmDataSource? alarmDataSource;
 
   setUp(() {
     mockDio = MockDio();
-    alarmDataSource = RemoteAlarmDataSource(mockDio!);
+    mockSecureStorageService = MockSecureStorageService();
+    alarmDataSource = RemoteAlarmDataSource(
+      mockDio!,
+      mockSecureStorageService!,
+    );
   });
 
   test('AlarmDataSource test', () async {
+    when(
+      () => mockSecureStorageService!.getUserIdx(),
+    ).thenAnswer((_) async => 1);
     final json = '''
 {
   "code": 201,

--- a/test/data/dream_repository_test.dart
+++ b/test/data/dream_repository_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:mongbi_app/data/data_sources/dream_analysis_data_source.dart';
+import 'package:mongbi_app/data/data_sources/dream_check_data_source.dart';
 import 'package:mongbi_app/data/data_sources/dream_save_data_source.dart';
 import 'package:mongbi_app/data/dtos/dream_dto.dart';
 import 'package:mongbi_app/data/repositories/remote_dream_repository.dart';
@@ -12,6 +13,7 @@ void main() {
   DreamSaveDataSource? dreamSaveDataSource;
   RemoteDreamRepository? remoteDreamRepository;
   MockDreamAnalysisDataSource? dreamAnalysisDataSource;
+  MockDreamCheckDataSource? dreamCheckDataSource;
 
   setUpAll(() {
     registerFallbackValue(FakeDreamDto());
@@ -21,9 +23,11 @@ void main() {
     setUp(() {
       dreamSaveDataSource = MockDreamDataSource();
       dreamAnalysisDataSource = MockDreamAnalysisDataSource();
+      dreamCheckDataSource = MockDreamCheckDataSource();
       remoteDreamRepository = RemoteDreamRepository(
         dreamSaveDataSource!,
         dreamAnalysisDataSource!,
+        dreamCheckDataSource!,
       );
     });
 
@@ -31,13 +35,13 @@ void main() {
       // Arrange
       when(
         () => dreamSaveDataSource!.saveDream(any()),
-      ).thenAnswer((_) async => true);
+      ).thenAnswer((_) async => 123);
 
       // Act
       final response = await remoteDreamRepository?.saveDream(dream);
 
       // Assert
-      expect(response, isTrue);
+      expect(response, 123);
       verify(() => dreamSaveDataSource!.saveDream(any())).called(1);
     });
 
@@ -61,14 +65,17 @@ void main() {
     setUp(() {
       dreamSaveDataSource = MockDreamDataSource();
       dreamAnalysisDataSource = MockDreamAnalysisDataSource();
+      dreamCheckDataSource = MockDreamCheckDataSource();
       remoteDreamRepository = RemoteDreamRepository(
         dreamSaveDataSource!,
         dreamAnalysisDataSource!,
+        dreamCheckDataSource!,
       );
     });
 
     test('DreamAnalysisDataSource에서 결과를 받아서 반환해야 한다', () async {
       // Arrange
+      final uid = 1;
       final dreamContent = '';
       final dreamScore = 4;
 
@@ -89,6 +96,7 @@ void main() {
 
       // Act
       final response = await remoteDreamRepository!.analyzeDream(
+        uid,
         dreamContent,
         dreamScore,
       );
@@ -103,6 +111,7 @@ void main() {
 
     test('DreamAnalysisDataSource에서 오류가 전달되면 호출한 곳에 오류를 전달한다.', () async {
       // Arrange
+      final uid = 1;
       final dreamContent = '';
       final dreamScore = 4;
 
@@ -112,7 +121,8 @@ void main() {
 
       // Act & Assert
       expect(
-        () => remoteDreamRepository!.analyzeDream(dreamContent, dreamScore),
+        () =>
+            remoteDreamRepository!.analyzeDream(uid, dreamContent, dreamScore),
         throwsA(isA<Exception>()),
       );
     });
@@ -123,6 +133,8 @@ class MockDreamDataSource extends Mock implements DreamSaveDataSource {}
 
 class MockDreamAnalysisDataSource extends Mock
     implements DreamAnalysisDataSource {}
+
+class MockDreamCheckDataSource extends Mock implements DreamCheckDataSource {}
 
 final dream = Dream(
   id: 1,

--- a/test/data/history_data_source_test.dart
+++ b/test/data/history_data_source_test.dart
@@ -3,57 +3,69 @@ import 'dart:convert';
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:mongbi_app/core/secure_storage_service.dart';
 import 'package:mongbi_app/data/data_sources/history_data_source.dart';
 import 'package:mongbi_app/data/data_sources/remote_history_data_source.dart';
 import 'package:mongbi_app/data/dtos/history_dto.dart';
 
 class MockDio extends Mock implements Dio {}
 
+class MockSecureStorageService extends Mock implements SecureStorageService {}
+
 void main() {
   MockDio? mockDio;
+  MockSecureStorageService? mockSecureStorageService;
   HistoryDataSource? historyDataSourceImpl;
 
   setUp(() {
     mockDio = MockDio();
-    historyDataSourceImpl = RemoteHistoryDataSource(mockDio!);
+    mockSecureStorageService = MockSecureStorageService();
+    historyDataSourceImpl = RemoteHistoryDataSource(
+      mockDio!,
+      mockSecureStorageService!,
+    );
   });
   test('HistoryDataSource test', () async {
-    // json이 이런 형태인 이유는
-    // fetchAllHistory 내부에서 ['result']로 값을 받기 때문
+    when(
+      () => mockSecureStorageService!.getUserIdx(),
+    ).thenAnswer((_) async => 1);
     final json = '''
 {
-  "results": [
+  "code": 201,
+  "success": true,
+  "data": [
     {
       "DREAM_CONTENT": "꿈1",
       "DREAM_SCORE": 1,
-      "DREAM_TAG": "꿈1",
       "DREAM_KEYWORDS": [
         "꿈1"
       ],
       "DREAM_INTERPRETATION": "꿈1",
-      "PSYCHOLOGICAL_STATELNTERPRETATION": "꿈1",
+      "PSYCHOLOGICAL_STATE_INTERPRETATION": "꿈1",
       "PSYCHOLOGICALSTATE_KEYWORDS": [
         "꿈1"
       ],
       "MONGBI_COMMENT": "꿈1",
-      "EMOTION_CATEGORY": "꿈1"
+      "DREAM_REG_DATE": "2025-06-20T00:00:00.000Z",
+      "DREAM_IDX": 1,
+      "USER_IDX": 1,
+      "CHALLENGE_IDX": 1,
+      "CHALLENGE_DESC": "챌린지 설명",
+      "CHALLENGE_TYPE": "챌린지 타입",
+      "CHALLENGE_STATUS": "ACTIVE"
     }
   ]
 }
 ''';
 
-    final map = jsonDecode(json);
-    final response = Response<Map<String, dynamic>>(
-      data: map,
-      statusCode: 200,
+    final jsonMap = jsonDecode(json);
+    final response = Response(
+      data: jsonMap,
+      statusCode: 201,
       requestOptions: RequestOptions(path: '/dream'),
     );
 
-    when(() {
-      return mockDio!.get(any());
-    }).thenAnswer((invocation) async {
-      return response;
-    });
+    when(() => mockDio!.get(any())).thenAnswer((_) async => response);
 
     final hisotoryDtoList =
         await historyDataSourceImpl!.feachUserDreamsHistory();

--- a/test/data/statistics_data_source_test.dart
+++ b/test/data/statistics_data_source_test.dart
@@ -1,22 +1,34 @@
 import 'dart:convert';
+
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:mongbi_app/core/secure_storage_service.dart';
 import 'package:mongbi_app/data/data_sources/remote_statistics_data_source.dart';
 import 'package:mongbi_app/data/data_sources/statistics_data_source.dart';
 import 'package:mongbi_app/data/dtos/statistics_dto.dart';
 
 class MockDio extends Mock implements Dio {}
 
+class MockSecureStorageService extends Mock implements SecureStorageService {}
+
 void main() {
   MockDio? mockDio;
+  MockSecureStorageService? mockSecureStorageService;
   StatisticsDataSource? remoteStatisticsDataSource;
 
   setUp(() {
     mockDio = MockDio();
-    remoteStatisticsDataSource = RemoteStatisticsDataSource(mockDio!);
+    mockSecureStorageService = MockSecureStorageService();
+    remoteStatisticsDataSource = RemoteStatisticsDataSource(
+      mockDio!,
+      mockSecureStorageService!,
+    );
   });
   test('StatisticsDataSource test', () async {
+    when(
+      () => mockSecureStorageService!.getUserIdx(),
+    ).thenAnswer((_) async => 1);
     final json = '''
 {
 "code": 201,
@@ -32,21 +44,21 @@ void main() {
       "5": 50
     },
     "MOOD_STATE": {
-      "GOOD_DREAM": {
+      "길몽": {
         "1": 0,
         "2": 3,
         "3": 4,
         "4": 2,
         "5": 7
       },
-      "ORDINARY_DREAM": {
+      "일상몽": {
         "1": 1,
         "2": 3,
         "3": 0,
         "4": 2,
         "5": 7
       },
-      "BAD_DREAM": {
+      "흉몽": {
         "1": 1,
         "2": 3,
         "3": 4,
@@ -80,18 +92,14 @@ void main() {
 }
 ''';
 
-    final map = jsonDecode(json);
-    final response = Response<Map<String, dynamic>>(
-      data: map,
+    final jsonMap = jsonDecode(json);
+    final response = Response(
+      data: jsonMap,
       statusCode: 201,
       requestOptions: RequestOptions(path: '/statistics'),
     );
 
-    when(() {
-      return mockDio!.get(any());
-    }).thenAnswer((invocation) async {
-      return response;
-    });
+    when(() => mockDio!.get(any())).thenAnswer((_) async => response);
 
     final statisticsDto = await remoteStatisticsDataSource!
         .fetchMonthStatistics(DateTime.now());

--- a/test/domain/analyze_and_save_dream_use_case_test.dart
+++ b/test/domain/analyze_and_save_dream_use_case_test.dart
@@ -1,17 +1,21 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:mongbi_app/domain/entities/dream.dart';
-import 'package:mongbi_app/domain/repositories/dream_repository.dart';
 import 'package:mongbi_app/domain/use_cases/analyze_and_save_dream_use_case.dart';
+import 'package:mongbi_app/domain/use_cases/analyze_dream_use_case.dart';
+import 'package:mongbi_app/domain/use_cases/save_dream_use_case.dart';
 
 void main() {
-  late MockDreamRepository mockDreamRepository;
+  late MockAnalyzeDreamUseCase mockAnalyzeDreamUseCase;
+  late MockSaveDreamUseCase mockSaveDreamUseCase;
   late AnalyzeAndSaveDreamUseCase analyzeAndSaveDreamUseCase;
 
   setUp(() {
-    mockDreamRepository = MockDreamRepository();
+    mockAnalyzeDreamUseCase = MockAnalyzeDreamUseCase();
+    mockSaveDreamUseCase = MockSaveDreamUseCase();
     analyzeAndSaveDreamUseCase = AnalyzeAndSaveDreamUseCase(
-      mockDreamRepository,
+      mockAnalyzeDreamUseCase,
+      mockSaveDreamUseCase,
     );
   });
 
@@ -34,33 +38,30 @@ void main() {
   test('analyze and save dream success test', () async {
     // Arrange
     when(
-      () => mockDreamRepository.analyzeDream('꿈 내용', 3),
+      () => mockAnalyzeDreamUseCase.execute(1, '꿈 내용', 3),
     ).thenAnswer((_) async => dream);
 
     when(
-      () => mockDreamRepository.saveDream(dream),
-    ).thenAnswer((_) async => true);
+      () => mockSaveDreamUseCase.execute(1, dream),
+    ).thenAnswer((_) async => 123);
 
     // Act
-    final result = await analyzeAndSaveDreamUseCase.execute('꿈 내용', 3);
+    final result = await analyzeAndSaveDreamUseCase.execute(1, '꿈 내용', 3);
 
     // Assert
-    expect(result, dream);
+    expect(result.id, 123);
+    expect(result.content, '꿈 내용');
   });
 
   test('analyze dream fail test', () {
     // Arrange
     when(
-      () => mockDreamRepository.analyzeDream('꿈 내용', 3),
+      () => mockAnalyzeDreamUseCase.execute(1, '꿈 내용', 3),
     ).thenThrow(Exception('failure'));
-
-    when(
-      () => mockDreamRepository.saveDream(dream),
-    ).thenAnswer((_) async => true);
 
     // Act && Assert
     expect(
-      () => analyzeAndSaveDreamUseCase.execute('꿈 내용', 3),
+      () => analyzeAndSaveDreamUseCase.execute(1, '꿈 내용', 3),
       throwsA(isA<Exception>()),
     );
   });
@@ -68,19 +69,21 @@ void main() {
   test('save dream fail test', () {
     // Arrange
     when(
-      () => mockDreamRepository.analyzeDream('꿈 내용', 3),
+      () => mockAnalyzeDreamUseCase.execute(1, '꿈 내용', 3),
     ).thenAnswer((_) async => dream);
 
     when(
-      () => mockDreamRepository.saveDream(dream),
+      () => mockSaveDreamUseCase.execute(1, dream),
     ).thenThrow(Exception('failure'));
 
     // Act && Assert
     expect(
-      () => analyzeAndSaveDreamUseCase.execute('꿈 내용', 3),
+      () => analyzeAndSaveDreamUseCase.execute(1, '꿈 내용', 3),
       throwsA(isA<Exception>()),
     );
   });
 }
 
-class MockDreamRepository extends Mock implements DreamRepository {}
+class MockAnalyzeDreamUseCase extends Mock implements AnalyzeDreamUseCase {}
+
+class MockSaveDreamUseCase extends Mock implements SaveDreamUseCase {}

--- a/test/domain/fetch_all_history_use_case_test.dart
+++ b/test/domain/fetch_all_history_use_case_test.dart
@@ -26,6 +26,9 @@ void main() {
           psychologicalStateKeywords: ['꿈1'],
           mongbiComment: '꿈1',
           dreamRegDate: DateTime.now(),
+          challengeDesc: '챌린지 설명',
+          challengeType: '챌린지 타입',
+          challengeStatus: 'ACTIVE',
         ),
       ];
     });


### PR DESCRIPTION
### 🚀 개요
iewModel에서 SecureStorageService 직접 접근 제거

### 🔧 작업 내용
- AuthViewModel에 userId getter 추가하여 중앙에서 사용자 ID 관리
- AuthViewModel에 _restoreUserFromStorage() 추가로 앱 시작 시 사용자 정보 자동 복원
- DreamWriteViewModel, HomeViewModel, ChallengeViewModel에서 SecureStorageService 직접 호출을 authViewModelProvider 사용으로 변경

### 💡 Issue
Closes #380 