### PR TITLE
[Auth] RefreshToken 갱신 누락

### DIFF
--- a/lib/core/auth_interceptor.dart
+++ b/lib/core/auth_interceptor.dart
@@ -73,6 +73,30 @@ class AuthInterceptor extends Interceptor {
           await storageService.clearAll();
           return handler.reject(err);
         }
+      } else {
+        // refreshToken이 없으면 로그아웃 처리
+        await storageService.clearAll();
+
+        await Sentry.captureMessage(
+          'RefreshToken이 없어서 로그아웃 처리',
+          level: SentryLevel.warning,
+          withScope: (scope) {
+            scope.setTag('error_type', 'no_refresh_token');
+            scope.setContexts('auth_error', {
+              'original_error': err.toString(),
+              'status_code': err.response?.statusCode,
+            });
+          },
+        );
+
+        return handler.reject(
+          DioException(
+            requestOptions: err.requestOptions,
+            error: 'RefreshToken이 없습니다. 다시 로그인해주세요.',
+            type: DioExceptionType.badResponse,
+            response: err.response,
+          ),
+        );
       }
     }
 

--- a/lib/core/auth_interceptor.dart
+++ b/lib/core/auth_interceptor.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:mongbi_app/core/secure_storage_service.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 class AuthInterceptor extends Interceptor {
   AuthInterceptor(this.dio);
@@ -21,10 +22,8 @@ class AuthInterceptor extends Interceptor {
     return handler.next(options);
   }
 
-
-
   @override
-  void onError(DioException err, ErrorInterceptorHandler handler) async { 
+  void onError(DioException err, ErrorInterceptorHandler handler) async {
     if (err.requestOptions.path.contains('/auth/refresh')) {
       return handler.reject(err);
     }
@@ -40,14 +39,37 @@ class AuthInterceptor extends Interceptor {
           );
 
           final newAccessToken = response.data['accessToken'];
+          final newRefreshToken = response.data['refreshToken'];
+
+          if (newAccessToken == null) {
+            throw Exception('AccessToken이 응답에 없습니다.');
+          }
+
           await storageService.saveAccessToken(newAccessToken);
+
+          if (newRefreshToken != null) {
+            await storageService.saveRefreshToken(newRefreshToken);
+          }
 
           final retryRequest = err.requestOptions;
           retryRequest.headers['Authorization'] = 'Bearer $newAccessToken';
 
           final clonedResponse = await dio.fetch(retryRequest);
           return handler.resolve(clonedResponse);
-        } catch (e) {
+        } catch (e, stackTrace) {
+          await Sentry.captureException(
+            e,
+            stackTrace: stackTrace,
+            withScope: (scope) {
+              scope.setTag('error_type', 'token_refresh_failed');
+              scope.setContexts('token_refresh_error', {
+                'original_error': err.toString(),
+                'error_message': e.toString(),
+                'status_code': err.response?.statusCode,
+              });
+            },
+          );
+
           await storageService.clearAll();
           return handler.reject(err);
         }


### PR DESCRIPTION
### 🔧 작업 내용
 - refresh token 갱신 시 저장 로직 추가
 - accessToken null 체크 강화
 - Sentry를 통한 토큰 갱신 실패 추적 개선

### 💡 Issue
Closes #396 

